### PR TITLE
Declare structures as immutable

### DIFF
--- a/src/Accumulate.php
+++ b/src/Accumulate.php
@@ -10,6 +10,8 @@ namespace Innmind\Immutable;
  * @template T
  * @template S
  * @internal Do not use this in your code
+ *
+ * @psalm-immutable
  */
 final class Accumulate implements \Iterator
 {
@@ -25,6 +27,7 @@ final class Accumulate implements \Iterator
      */
     public function __construct(\Generator $generator)
     {
+        /** @psalm-suppress ImpurePropertyAssignment */
         $this->generator = $generator;
     }
 
@@ -54,6 +57,7 @@ final class Accumulate implements \Iterator
         \next($this->values);
 
         if ($this->reachedCacheEnd()) {
+            /** @psalm-suppress ImpureMethodCall */
             $this->generator->next();
         }
     }
@@ -66,6 +70,7 @@ final class Accumulate implements \Iterator
 
     public function valid(): bool
     {
+        /** @psalm-suppress ImpureMethodCall */
         return !$this->reachedCacheEnd() || $this->generator->valid();
     }
 
@@ -77,7 +82,15 @@ final class Accumulate implements \Iterator
     private function pop(): void
     {
         if ($this->reachedCacheEnd()) {
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @psalm-suppress InaccessibleProperty
+             */
             $this->keys[] = $this->generator->key();
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @psalm-suppress InaccessibleProperty
+             */
             $this->values[] = $this->generator->current();
         }
     }

--- a/src/Map.php
+++ b/src/Map.php
@@ -13,6 +13,7 @@ use Innmind\Immutable\{
 /**
  * @template T
  * @template S
+ * @psalm-immutable
  */
 final class Map implements \Countable
 {
@@ -38,6 +39,7 @@ final class Map implements \Countable
     /**
      * @template U
      * @template V
+     * @psalm-pure
      *
      * @return self<U, V>
      */
@@ -87,7 +89,7 @@ final class Map implements \Countable
      */
     public function count(): int
     {
-        return $this->implementation->count();
+        return $this->size();
     }
 
     /**
@@ -192,7 +194,7 @@ final class Map implements \Countable
      */
     public function filter(callable $predicate): self
     {
-        $map = $this->clear();
+        $map = clone $this;
         $map->implementation = $this->implementation->filter($predicate);
 
         return $map;
@@ -255,7 +257,7 @@ final class Map implements \Countable
      */
     public function map(callable $function): self
     {
-        $map = $this->clear();
+        $map = clone $this;
         $map->implementation = $this->implementation->map($function);
 
         return $map;

--- a/src/Map/DoubleIndex.php
+++ b/src/Map/DoubleIndex.php
@@ -19,6 +19,7 @@ use Innmind\Immutable\{
 /**
  * @template T
  * @template S
+ * @psalm-immutable
  */
 final class DoubleIndex implements Implementation
 {
@@ -62,7 +63,7 @@ final class DoubleIndex implements Implementation
 
     public function count(): int
     {
-        return $this->keys->count();
+        return $this->size();
     }
 
     /**
@@ -162,7 +163,10 @@ final class DoubleIndex implements Implementation
      */
     public function filter(callable $predicate): self
     {
-        $map = $this->clear();
+        $map = clone $this;
+        $map->keys = $this->keys->clear();
+        $map->values = $this->values->clear();
+        $map->pairs = $this->pairs->clear();
 
         foreach ($this->pairs->iterator() as $pair) {
             if ($predicate($pair->key(), $pair->value()) === true) {

--- a/src/Map/Implementation.php
+++ b/src/Map/Implementation.php
@@ -17,6 +17,7 @@ use Innmind\Immutable\{
  * @template T
  * @template S
  * @internal Dot not code against this interface
+ * @psalm-immutable
  */
 interface Implementation extends \Countable
 {

--- a/src/Map/ObjectKeys.php
+++ b/src/Map/ObjectKeys.php
@@ -20,6 +20,7 @@ use Innmind\Immutable\{
 /**
  * @template T
  * @template S
+ * @psalm-immutable
  */
 final class ObjectKeys implements Implementation
 {
@@ -40,6 +41,7 @@ final class ObjectKeys implements Implementation
         $this->validateValue = Type::of($valueType);
         $this->keyType = $keyType;
         $this->valueType = $valueType;
+        /** @psalm-suppress ImpurePropertyAssignment */
         $this->values = new \SplObjectStorage;
     }
 
@@ -55,6 +57,7 @@ final class ObjectKeys implements Implementation
 
     public function size(): int
     {
+        /** @psalm-suppress ImpureMethodCall */
         return $this->values->count();
     }
 
@@ -79,7 +82,10 @@ final class ObjectKeys implements Implementation
 
         $map = clone $this;
         $map->values = clone $this->values;
-        /** @psalm-suppress MixedArgumentTypeCoercion */
+        /**
+         * @psalm-suppress MixedArgumentTypeCoercion
+         * @psalm-suppress ImpureMethodCall
+         */
         $map->values[$key] = $value;
 
         return $map;
@@ -100,6 +106,7 @@ final class ObjectKeys implements Implementation
 
         /**
          * @psalm-suppress MixedArgumentTypeCoercion
+         * @psalm-suppress ImpureMethodCall
          * @var S
          */
         return $this->values->offsetGet($key);
@@ -114,7 +121,10 @@ final class ObjectKeys implements Implementation
             return false;
         }
 
-        /** @psalm-suppress MixedArgumentTypeCoercion */
+        /**
+         * @psalm-suppress MixedArgumentTypeCoercion
+         * @psalm-suppress ImpureMethodCall
+         */
         return $this->values->offsetExists($key);
     }
 
@@ -124,6 +134,7 @@ final class ObjectKeys implements Implementation
     public function clear(): self
     {
         $map = clone $this;
+        /** @psalm-suppress ImpurePropertyAssignment */
         $map->values = new \SplObjectStorage;
 
         return $map;
@@ -138,6 +149,7 @@ final class ObjectKeys implements Implementation
             return false;
         }
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
@@ -163,15 +175,22 @@ final class ObjectKeys implements Implementation
      */
     public function filter(callable $predicate): self
     {
-        $map = $this->clear();
+        $map = clone $this;
+        /** @psalm-suppress ImpurePropertyAssignment */
+        $map->values = new \SplObjectStorage;
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             if ($predicate($key, $v) === true) {
+                /** @psalm-suppress ImpurePropertyAssignment */
                 $map->values[$k] = $v;
             }
         }
@@ -184,10 +203,14 @@ final class ObjectKeys implements Implementation
      */
     public function foreach(callable $function): void
     {
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             $function($key, $v);
@@ -210,10 +233,14 @@ final class ObjectKeys implements Implementation
 
         $groups = null;
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             $discriminant = $discriminator($key, $v);
@@ -276,12 +303,18 @@ final class ObjectKeys implements Implementation
      */
     public function map(callable $function): self
     {
-        $map = $this->clear();
+        $map = clone $this;
+        /** @psalm-suppress ImpurePropertyAssignment */
+        $map->values = new \SplObjectStorage;
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T */
             $key = $k;
-            /** @var S */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             $return = $function($key, $v);
@@ -300,6 +333,7 @@ final class ObjectKeys implements Implementation
 
             ($this->validateValue)($value, 2);
 
+            /** @psalm-suppress ImpurePropertyAssignment */
             $map->values[$key] = $value;
         }
 
@@ -319,8 +353,12 @@ final class ObjectKeys implements Implementation
 
         $map = clone $this;
         $map->values = clone $this->values;
-        /** @psalm-suppress MixedArgumentTypeCoercion */
+        /**
+         * @psalm-suppress MixedArgumentTypeCoercion
+         * @psalm-suppress ImpureMethodCall
+         */
         $map->values->detach($key);
+        /** @psalm-suppress ImpureMethodCall */
         $map->values->rewind();
 
         return $map;
@@ -349,10 +387,14 @@ final class ObjectKeys implements Implementation
         $truthy = $this->clearMap();
         $falsy = $this->clearMap();
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             $return = $predicate($key, $v);
@@ -383,10 +425,14 @@ final class ObjectKeys implements Implementation
      */
     public function reduce($carry, callable $reducer)
     {
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             $carry = $reducer($carry, $key, $v);
@@ -397,8 +443,10 @@ final class ObjectKeys implements Implementation
 
     public function empty(): bool
     {
+        /** @psalm-suppress ImpureMethodCall */
         $this->values->rewind();
 
+        /** @psalm-suppress ImpureMethodCall */
         return !$this->values->valid();
     }
 
@@ -414,10 +462,14 @@ final class ObjectKeys implements Implementation
         /** @var Sequence<ST> */
         $sequence = Sequence::of($type);
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             foreach ($mapper($key, $v) as $newValue) {
@@ -440,10 +492,14 @@ final class ObjectKeys implements Implementation
         /** @var Set<ST> */
         $set = Set::of($type);
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             foreach ($mapper($key, $v) as $newValue) {
@@ -470,10 +526,14 @@ final class ObjectKeys implements Implementation
         /** @var Map<MT, MS> */
         $map = Map::of($key, $value);
 
+        /** @psalm-suppress ImpureMethodCall */
         foreach ($this->values as $k) {
             /** @var T $key */
             $key = $k;
-            /** @var S $v */
+            /**
+             * @psalm-suppress ImpureMethodCall
+             * @var S $v
+             */
             $v = $this->values[$k];
 
             foreach ($mapper($key, $v) as $newKey => $newValue) {

--- a/src/Map/Primitive.php
+++ b/src/Map/Primitive.php
@@ -19,6 +19,7 @@ use Innmind\Immutable\{
 /**
  * @template T
  * @template S
+ * @psalm-immutable
  */
 final class Primitive implements Implementation
 {
@@ -28,7 +29,6 @@ final class Primitive implements Implementation
     private ValidateArgument $validateValue;
     /** @var array<T, S> */
     private array $values = [];
-    private ?int $size = null;
 
     public function __construct(string $keyType, string $valueType)
     {
@@ -56,7 +56,7 @@ final class Primitive implements Implementation
     public function size(): int
     {
         /** @psalm-suppress MixedArgumentTypeCoercion */
-        return $this->size ?? $this->size = \count($this->values);
+        return \count($this->values);
     }
 
     /**
@@ -79,7 +79,6 @@ final class Primitive implements Implementation
         ($this->validateValue)($value, 2);
 
         $map = clone $this;
-        $map->size = null;
         $map->values[$key] = $value;
 
         return $map;
@@ -116,7 +115,6 @@ final class Primitive implements Implementation
     public function clear(): self
     {
         $map = clone $this;
-        $map->size = null;
         $map->values = [];
 
         return $map;
@@ -151,7 +149,8 @@ final class Primitive implements Implementation
      */
     public function filter(callable $predicate): self
     {
-        $map = $this->clear();
+        $map = clone $this;
+        $map->values = [];
 
         foreach ($this->values as $k => $v) {
             if ($predicate($this->normalizeKey($k), $v) === true) {
@@ -257,7 +256,8 @@ final class Primitive implements Implementation
      */
     public function map(callable $function): self
     {
-        $map = $this->clear();
+        $map = clone $this;
+        $map->values = [];
 
         foreach ($this->values as $k => $v) {
             $return = $function($this->normalizeKey($k), $v);
@@ -294,7 +294,6 @@ final class Primitive implements Implementation
         }
 
         $map = clone $this;
-        $map->size = null;
         /** @psalm-suppress MixedArrayTypeCoercion */
         unset($map->values[$key]);
 

--- a/src/Pair.php
+++ b/src/Pair.php
@@ -8,6 +8,7 @@ namespace Innmind\Immutable;
  *
  * @template T
  * @template S
+ * @psalm-immutable
  */
 final class Pair
 {

--- a/src/RegExp.php
+++ b/src/RegExp.php
@@ -8,6 +8,9 @@ use Innmind\Immutable\Exception\{
     RegexException,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class RegExp
 {
     private string $pattern;
@@ -15,12 +18,16 @@ final class RegExp
     private function __construct(string $pattern)
     {
         if (@\preg_match($pattern, '') === false) {
+            /** @psalm-suppress ImpureFunctionCall */
             throw new DomainException($pattern, \preg_last_error());
         }
 
         $this->pattern = $pattern;
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function of(string $pattern): self
     {
         return new self($pattern);
@@ -34,6 +41,7 @@ final class RegExp
         $value = \preg_match($this->pattern, $string->toString());
 
         if ($value === false) {
+            /** @psalm-suppress ImpureFunctionCall */
             throw new RegexException('', \preg_last_error());
         }
 
@@ -52,6 +60,7 @@ final class RegExp
         $value = \preg_match($this->pattern, $string->toString(), $matches);
 
         if ($value === false) {
+            /** @psalm-suppress ImpureFunctionCall */
             throw new RegexException('', \preg_last_error());
         }
 

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -13,6 +13,7 @@ use Innmind\Immutable\Exception\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Sequence implements \Countable
 {
@@ -29,6 +30,7 @@ final class Sequence implements \Countable
 
     /**
      * @template V
+     * @psalm-pure
      *
      * @param V $values
      *
@@ -56,6 +58,7 @@ final class Sequence implements \Countable
      * Use this mode when the amount of data may not fit in memory
      *
      * @template V
+     * @psalm-pure
      *
      * @param \Generator<V> $generator
      *
@@ -75,6 +78,7 @@ final class Sequence implements \Countable
      * as parsing a file or calling an API
      *
      * @template V
+     * @psalm-pure
      *
      * @param callable(): \Generator<V> $generator
      *
@@ -86,6 +90,8 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed $values
      *
      * @return self<mixed>
@@ -96,6 +102,8 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<int>
      */
     public static function ints(int ...$values): self
@@ -107,6 +115,8 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<float>
      */
     public static function floats(float ...$values): self
@@ -118,6 +128,8 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<string>
      */
     public static function strings(string ...$values): self
@@ -129,6 +141,8 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<object>
      */
     public static function objects(object ...$values): self

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -20,6 +20,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Defer implements Implementation
 {
@@ -54,7 +55,7 @@ final class Defer implements Implementation
 
     public function count(): int
     {
-        return $this->load()->count();
+        return $this->size();
     }
 
     /**
@@ -545,8 +546,10 @@ final class Defer implements Implementation
 
     public function empty(): bool
     {
+        /** @psalm-suppress ImpureMethodCall */
         $this->values->rewind();
 
+        /** @psalm-suppress ImpureMethodCall */
         return !$this->values->valid();
     }
 

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -17,6 +17,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 interface Implementation extends \Countable
 {

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -19,6 +19,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Lazy implements Implementation
 {
@@ -26,13 +27,15 @@ final class Lazy implements Implementation
     /** @var \Closure(): \Generator<T> */
     private \Closure $values;
     private ValidateArgument $validate;
-    private ?int $size = null;
 
     public function __construct(string $type, callable $generator)
     {
         $this->type = $type;
         $validate = Type::of($type);
-        /** @var \Closure(): \Generator<T> */
+        /**
+         * @psalm-suppress ImpurePropertyAssignment
+         * @var \Closure(): \Generator<T>
+         */
         $this->values = \Closure::fromCallable(static function() use ($generator, $validate): \Generator {
             /** @var T $value */
             foreach ($generator() as $value) {
@@ -50,17 +53,13 @@ final class Lazy implements Implementation
 
     public function size(): int
     {
-        if (\is_int($this->size)) {
-            return $this->size;
-        }
-
         $size = 0;
 
         foreach ($this->iterator() as $_) {
             ++$size;
         }
 
-        return $this->size = $size;
+        return $size;
     }
 
     public function count(): int
@@ -581,6 +580,7 @@ final class Lazy implements Implementation
 
     public function empty(): bool
     {
+        /** @psalm-suppress ImpureMethodCall */
         return !$this->iterator()->valid();
     }
 

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -19,6 +19,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Primitive implements Implementation
 {
@@ -26,7 +27,6 @@ final class Primitive implements Implementation
     private ValidateArgument $validate;
     /** @var list<T> */
     private array $values;
-    private ?int $size = null;
 
     /**
      * @param T $values
@@ -45,7 +45,7 @@ final class Primitive implements Implementation
 
     public function size(): int
     {
-        return $this->size ?? $this->size = \count($this->values);
+        return \count($this->values);
     }
 
     public function count(): int
@@ -112,7 +112,7 @@ final class Primitive implements Implementation
      */
     public function drop(int $size): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->values = \array_slice($this->values, $size);
 
         return $self;
@@ -123,7 +123,7 @@ final class Primitive implements Implementation
      */
     public function dropEnd(int $size): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->values = \array_slice($this->values, 0, $this->size() - $size);
 
         return $self;
@@ -144,7 +144,7 @@ final class Primitive implements Implementation
      */
     public function filter(callable $predicate): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->values = \array_values(\array_filter(
             $this->values,
             $predicate,
@@ -295,7 +295,7 @@ final class Primitive implements Implementation
      */
     public function pad(int $size, $element): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->values = \array_pad($this->values, $size, $element);
 
         return $self;
@@ -341,7 +341,7 @@ final class Primitive implements Implementation
      */
     public function slice(int $from, int $until): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->values = \array_slice(
             $this->values,
             $from,
@@ -389,9 +389,12 @@ final class Primitive implements Implementation
      */
     public function append(Implementation $sequence): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         /** @var list<T> */
-        $self->values = \array_merge($this->values, \iterator_to_array($sequence->iterator()));
+        $self->values = \array_merge(
+            $this->values,
+            \iterator_to_array($sequence->iterator()),
+        );
 
         return $self;
     }
@@ -419,7 +422,6 @@ final class Primitive implements Implementation
     {
         $self = clone $this;
         $self->values[] = $element;
-        $self->size = $this->size() + 1;
 
         return $self;
     }

--- a/src/Set.php
+++ b/src/Set.php
@@ -10,6 +10,7 @@ use Innmind\Immutable\Exception\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Set implements \Countable
 {
@@ -29,6 +30,7 @@ final class Set implements \Countable
 
     /**
      * @template V
+     * @psalm-pure
      *
      * @param V $values
      *
@@ -46,6 +48,7 @@ final class Set implements \Countable
      * Use this mode when the amount of data may not fit in memory
      *
      * @template V
+     * @psalm-pure
      *
      * @param \Generator<V> $generator
      *
@@ -65,6 +68,7 @@ final class Set implements \Countable
      * as parsing a file or calling an API
      *
      * @template V
+     * @psalm-pure
      *
      * @param callable(): \Generator<V> $generator
      *
@@ -76,6 +80,8 @@ final class Set implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed $values
      *
      * @return self<mixed>
@@ -86,6 +92,8 @@ final class Set implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<int>
      */
     public static function ints(int ...$values): self
@@ -97,6 +105,8 @@ final class Set implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<float>
      */
     public static function floats(float ...$values): self
@@ -108,6 +118,8 @@ final class Set implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<string>
      */
     public static function strings(string ...$values): self
@@ -119,6 +131,8 @@ final class Set implements \Countable
     }
 
     /**
+     * @psalm-pure
+     *
      * @return self<object>
      */
     public static function objects(object ...$values): self
@@ -318,7 +332,7 @@ final class Set implements \Countable
      */
     public function map(callable $function): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->implementation = $this->implementation->map($function);
 
         return $self;

--- a/src/Set/Defer.php
+++ b/src/Set/Defer.php
@@ -15,6 +15,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Defer implements Implementation
 {

--- a/src/Set/Implementation.php
+++ b/src/Set/Implementation.php
@@ -14,6 +14,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 interface Implementation extends \Countable
 {

--- a/src/Set/Lazy.php
+++ b/src/Set/Lazy.php
@@ -15,6 +15,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Lazy implements Implementation
 {

--- a/src/Set/Primitive.php
+++ b/src/Set/Primitive.php
@@ -15,6 +15,7 @@ use Innmind\Immutable\{
 
 /**
  * @template T
+ * @psalm-immutable
  */
 final class Primitive implements Implementation
 {
@@ -65,7 +66,7 @@ final class Primitive implements Implementation
      */
     public function intersect(Implementation $set): self
     {
-        $self = $this->clear();
+        $self = clone $this;
         $self->values = $this->values->intersect(
             new Sequence\Primitive($this->type, ...$set->iterator()),
         );

--- a/src/Str.php
+++ b/src/Str.php
@@ -9,6 +9,9 @@ use Innmind\Immutable\{
     Exception\LogicException,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class Str
 {
     private string $value;
@@ -17,10 +20,16 @@ final class Str
     private function __construct(string $value, string $encoding = null)
     {
         $this->value = $value;
-        /** @var string */
+        /**
+         * @psalm-suppress ImpureFunctionCall
+         * @var string
+         */
         $this->encoding = $encoding ?? \mb_internal_encoding();
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function of(string $value, string $encoding = null): self
     {
         return new self($value, $encoding);
@@ -358,6 +367,7 @@ final class Str
         );
 
         if ($value === null) {
+            /** @psalm-suppress ImpureFunctionCall */
             throw new RegexException('', \preg_last_error());
         }
 

--- a/src/Type.php
+++ b/src/Type.php
@@ -20,6 +20,8 @@ final class Type
 {
     /**
      * Build the appropriate specification for the given type
+     *
+     * @psalm-pure
      */
     public static function of(string $type): ValidateArgument
     {

--- a/src/Type.php
+++ b/src/Type.php
@@ -13,6 +13,9 @@ use Innmind\Immutable\ValidateArgument\{
     ResourceType,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class Type
 {
     /**
@@ -60,6 +63,8 @@ final class Type
     /**
      * Return the type of the given value
      *
+     * @psalm-pure
+     *
      * @param mixed $value
      *
      * @return string
@@ -89,6 +94,9 @@ final class Type
         }
     }
 
+    /**
+     * @psalm-pure
+     */
     private static function ofPrimitive(string $type): ValidateArgument
     {
         if ($type === 'resource') {

--- a/src/ValidateArgument.php
+++ b/src/ValidateArgument.php
@@ -3,10 +3,15 @@ declare(strict_types = 1);
 
 namespace Innmind\Immutable;
 
+/**
+ * @psalm-immutable
+ */
 interface ValidateArgument
 {
     /**
      * Check if the given value is validated by the spec
+     *
+     * @psalm-pure
      *
      * @param mixed $value
      *

--- a/src/ValidateArgument/ClassType.php
+++ b/src/ValidateArgument/ClassType.php
@@ -8,6 +8,9 @@ use Innmind\Immutable\{
     Type,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class ClassType implements ValidateArgument
 {
     private string $class;

--- a/src/ValidateArgument/MixedType.php
+++ b/src/ValidateArgument/MixedType.php
@@ -5,6 +5,9 @@ namespace Innmind\Immutable\ValidateArgument;
 
 use Innmind\Immutable\ValidateArgument;
 
+/**
+ * @psalm-immutable
+ */
 final class MixedType implements ValidateArgument
 {
     /**

--- a/src/ValidateArgument/NullableType.php
+++ b/src/ValidateArgument/NullableType.php
@@ -5,6 +5,9 @@ namespace Innmind\Immutable\ValidateArgument;
 
 use Innmind\Immutable\ValidateArgument;
 
+/**
+ * @psalm-immutable
+ */
 final class NullableType implements ValidateArgument
 {
     private ValidateArgument $validate;

--- a/src/ValidateArgument/PrimitiveType.php
+++ b/src/ValidateArgument/PrimitiveType.php
@@ -8,6 +8,9 @@ use Innmind\Immutable\{
     Type,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class PrimitiveType implements ValidateArgument
 {
     /** @var callable */

--- a/src/ValidateArgument/ResourceType.php
+++ b/src/ValidateArgument/ResourceType.php
@@ -8,6 +8,9 @@ use Innmind\Immutable\{
     Type,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class ResourceType implements ValidateArgument
 {
     /**

--- a/src/ValidateArgument/UnionType.php
+++ b/src/ValidateArgument/UnionType.php
@@ -8,6 +8,9 @@ use Innmind\Immutable\{
     Type,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class UnionType implements ValidateArgument
 {
     private string $type;

--- a/src/functions.php
+++ b/src/functions.php
@@ -10,6 +10,7 @@ use Innmind\Immutable\Exception\{
 
 /**
  * @template T
+ * @psalm-pure
  *
  * @param Set<T>|Sequence<T> $structure
  *
@@ -42,6 +43,8 @@ function unwrap($structure): array
 /**
  * Concatenate all elements with the given separator
  *
+ * @psalm-pure
+ *
  * @param Set<string>|Sequence<string> $structure
  */
 function join(string $separator, $structure): Str
@@ -64,6 +67,7 @@ function join(string $separator, $structure): Str
 
 /**
  * @template T
+ * @psalm-pure
  *
  * @throws EmptySet
  *
@@ -81,6 +85,8 @@ function first(Set $set)
 }
 
 /**
+ * @psalm-pure
+ *
  * @throws \TypeError
  */
 function assertSet(string $type, Set $set, int $position): void
@@ -91,6 +97,8 @@ function assertSet(string $type, Set $set, int $position): void
 }
 
 /**
+ * @psalm-pure
+ *
  * @throws \TypeError
  */
 function assertMap(string $key, string $value, Map $map, int $position): void
@@ -101,6 +109,8 @@ function assertMap(string $key, string $value, Map $map, int $position): void
 }
 
 /**
+ * @psalm-pure
+ *
  * @throws \TypeError
  */
 function assertSequence(string $type, Sequence $sequence, int $position): void

--- a/tests/Map/DoubleIndexTest.php
+++ b/tests/Map/DoubleIndexTest.php
@@ -38,7 +38,9 @@ class DoubleIndexTest extends TestCase
         $m2 = ($m)(42, 42);
         $this->assertNotSame($m, $m2);
         $this->assertSame(0, $m->size());
+        $this->assertSame($m->count(), $m->size());
         $this->assertSame(1, $m2->size());
+        $this->assertSame($m2->count(), $m2->size());
 
         $m = new DoubleIndex('int', 'int');
         $m = $m
@@ -53,6 +55,7 @@ class DoubleIndexTest extends TestCase
         $this->assertSame(1, $m->get(65));
         $this->assertSame(90, $m->get(89));
         $this->assertSame(4, $m->size());
+        $this->assertSame($m->count(), $m->size());
     }
 
     public function testThrowWhenKeyDoesntMatchType()

--- a/tests/Map/ObjectKeysTest.php
+++ b/tests/Map/ObjectKeysTest.php
@@ -45,7 +45,9 @@ class ObjectKeysTest extends TestCase
         $m2 = ($m)(new \stdClass, 42);
         $this->assertNotSame($m, $m2);
         $this->assertSame(0, $m->size());
+        $this->assertSame($m->count(), $m->size());
         $this->assertSame(1, $m2->size());
+        $this->assertSame($m2->count(), $m2->size());
 
         $m = new ObjectKeys('stdClass', 'int');
         $m = $m
@@ -60,6 +62,7 @@ class ObjectKeysTest extends TestCase
         $this->assertSame(1, $m->get($c));
         $this->assertSame(90, $m->get($d));
         $this->assertSame(4, $m->size());
+        $this->assertSame($m->count(), $m->size());
     }
 
     public function testThrowWhenKeyDoesntMatchType()

--- a/tests/Map/PrimitiveTest.php
+++ b/tests/Map/PrimitiveTest.php
@@ -52,7 +52,9 @@ class PrimitiveTest extends TestCase
         $m2 = ($m)(42, 42);
         $this->assertNotSame($m, $m2);
         $this->assertSame(0, $m->size());
+        $this->assertSame($m->count(), $m->size());
         $this->assertSame(1, $m2->size());
+        $this->assertSame($m2->count(), $m2->size());
 
         $m = new Primitive('int', 'int');
         $m = $m
@@ -67,6 +69,7 @@ class PrimitiveTest extends TestCase
         $this->assertSame(1, $m->get(65));
         $this->assertSame(90, $m->get(89));
         $this->assertSame(4, $m->size());
+        $this->assertSame($m->count(), $m->size());
     }
 
     public function testThrowWhenKeyDoesntMatchType()

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -527,4 +527,16 @@ class SetTest extends TestCase
 
         $sequence->find(fn($i) => $i === 0);
     }
+
+    public function testClear()
+    {
+        $set = Set::ints(1, 2, 3);
+        $emptySet = $set->clear();
+
+        $this->assertInstanceOf(Set::class, $emptySet);
+        $this->assertSame('int', $emptySet->type());
+        $this->assertNotSame($emptySet, $set);
+        $this->assertSame([1, 2, 3], unwrap($set));
+        $this->assertSame([], unwrap($emptySet));
+    }
 }


### PR DESCRIPTION
As suggested in #6 the structures should be declared immutable.

This declaration makes me wonder about a few things : 
- this library used mutable objects in order to produce immutable ones (specifically `\SplObjectStorage` and `Accumulate`) resulting in the use of `@psalm-suppress` annotations (for this case I think it's okay)
- `Set` and `Sequence` have a `lazy` method that use a function returning generators that will provide the elements of the structures. This is helpful to generate structures that can't fit in memory (such as an API paginated list), it acts like an immutable structure but typewise it is not since 2 iterations on the structure may generate different results. For this case I am not sure it's okay that the structure is declared immutable