### PR TITLE
Add `Sequence::prepend()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\Immutable\Sequence::prepend()`
+
 ## 5.6.0 - 2024-06-15
 
 ### Added

--- a/docs/structures/sequence.md
+++ b/docs/structures/sequence.md
@@ -104,6 +104,15 @@ $sequence = Sequence::ints(1, 2)->append(Sequence::ints(3, 4));
 $sequence->equals(Sequence::ints(1, 2, 3, 4)); // true
 ```
 
+### `->prepend()`
+
+This is similar to `->append()` except the order is switched.
+
+!!! success ""
+    The main advantage of this method is when using lazy sequences. If you want to add elements at the beginning of a sequence but the rest may be lazy then you need to create a lazy sequence with your values and then append the other lazy sequence; but this reveals the underlying lazyness of the call and you need to be aware that it could be lazy.
+
+    Instead by using this method you no longer have to be aware that the other sequence is lazy or not.
+
 ## Access values
 
 ### `->size()` :material-memory-arrow-down:

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 
 use Innmind\Immutable\Sequence;
+use Innmind\BlackBox\Set;
 
 return static function() {
     yield test(
@@ -12,6 +13,44 @@ return static function() {
             $assert->same(
                 $sequence,
                 $sequence->toIdentity()->unwrap(),
+            );
+        },
+    );
+
+    yield proof(
+        'Sequence::prepend()',
+        given(
+            Set\Sequence::of(Set\Type::any()),
+            Set\Sequence::of(Set\Type::any()),
+        ),
+        static function($assert, $first, $second) {
+            $assert->same(
+                [...$first, ...$second],
+                Sequence::of(...$second)
+                    ->prepend(Sequence::of(...$first))
+                    ->toList(),
+            );
+
+            $assert->same(
+                [...$first, ...$second],
+                Sequence::defer((static function() use ($second) {
+                    yield from $second;
+                })())
+                    ->prepend(Sequence::defer((static function() use ($first) {
+                        yield from $first;
+                    })()))
+                    ->toList(),
+            );
+
+            $assert->same(
+                [...$first, ...$second],
+                Sequence::lazy(static function() use ($second) {
+                    yield from $second;
+                })
+                    ->prepend(Sequence::lazy(static function() use ($first) {
+                        yield from $first;
+                    }))
+                    ->toList(),
             );
         },
     );

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -490,6 +490,20 @@ final class Sequence implements \Countable
     }
 
     /**
+     * Prepend the given sequence to the current one
+     *
+     * @param self<T> $sequence
+     *
+     * @return self<T>
+     */
+    public function prepend(self $sequence): self
+    {
+        return new self($this->implementation->prepend(
+            $sequence->implementation,
+        ));
+    }
+
+    /**
      * Return a sequence with all elements from the current one that exist
      * in the given one
      *

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -488,6 +488,29 @@ final class Defer implements Implementation
      *
      * @return Implementation<T>
      */
+    public function prepend(Implementation $sequence): Implementation
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return new self(
+            (static function(\Iterator $values, Implementation $sequence): \Generator {
+                /** @var T $value */
+                foreach ($sequence->iterator() as $value) {
+                    yield $value;
+                }
+
+                /** @var T $value */
+                foreach ($values as $value) {
+                    yield $value;
+                }
+            })($this->values, $sequence),
+        );
+    }
+
+    /**
+     * @param Implementation<T> $sequence
+     *
+     * @return Implementation<T>
+     */
     public function intersect(Implementation $sequence): Implementation
     {
         return $this->filter(static function(mixed $value) use ($sequence): bool {

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -229,6 +229,15 @@ interface Implementation extends \Countable
     public function append(self $sequence): self;
 
     /**
+     * Prepend the given sequence to the current one
+     *
+     * @param self<T> $sequence
+     *
+     * @return self<T>
+     */
+    public function prepend(self $sequence): self;
+
+    /**
      * Return a sequence with all elements from the current one that exist
      * in the given one
      *

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -522,6 +522,31 @@ final class Lazy implements Implementation
      *
      * @return Implementation<T>
      */
+    public function prepend(Implementation $sequence): Implementation
+    {
+        $values = $this->values;
+
+        return new self(
+            static function(RegisterCleanup $registerCleanup) use ($values, $sequence): \Generator {
+                /** @var \Iterator<int, T> */
+                $generator = self::open($sequence, $registerCleanup);
+
+                foreach ($generator as $value) {
+                    yield $value;
+                }
+
+                foreach ($values($registerCleanup) as $value) {
+                    yield $value;
+                }
+            },
+        );
+    }
+
+    /**
+     * @param Implementation<T> $sequence
+     *
+     * @return Implementation<T>
+     */
     public function intersect(Implementation $sequence): Implementation
     {
         return $this->filter(static function(mixed $value) use ($sequence): bool {

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -368,6 +368,22 @@ final class Primitive implements Implementation
      *
      * @return self<T>
      */
+    public function prepend(Implementation $sequence): self
+    {
+        $other = [];
+
+        foreach ($sequence->iterator() as $value) {
+            $other[] = $value;
+        }
+
+        return new self(\array_merge($other, $this->values));
+    }
+
+    /**
+     * @param Implementation<T> $sequence
+     *
+     * @return self<T>
+     */
     public function intersect(Implementation $sequence): self
     {
         return $this->filter(static function(mixed $value) use ($sequence): bool {


### PR DESCRIPTION
This method allows to no longer have to be aware when appending another sequence is lazy or not. 

This may result in the method `Sequence::lazyStartingWith()` being deprecated later on.