### PR TITLE
Add possibility to nest lazy `Sequence`s through a lazy `Identity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Innmind\Immutable\Identity::lazy()`
 - `Innmind\Immutable\Identity::defer()`
+- `Innmind\Immutable\Identity::toSequence()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `Innmind\Immutable\Identity::lazy()`
 - `Innmind\Immutable\Identity::defer()`
 
+### Changed
+
+- `Innmind\Immutable\Sequence::toIdentity()` returns a lazy, deferred or in memory `Identity` based on the kind of `Sequence`
+
 ## 5.7.0 - 2024-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\Immutable\Identity::lazy()`
+- `Innmind\Immutable\Identity::defer()`
+
 ## 5.7.0 - 2024-06-25
 
 ### Added

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -5,14 +5,18 @@ use Innmind\Immutable\Sequence;
 use Innmind\BlackBox\Set;
 
 return static function() {
-    yield test(
+    yield proof(
         'Sequence::toIdentity()',
-        static function($assert) {
-            $sequence = Sequence::of();
+        given(Set\Sequence::of(Set\Type::any())),
+        static function($assert, $values) {
+            $sequence = Sequence::of(...$values);
 
             $assert->same(
-                $sequence,
-                $sequence->toIdentity()->unwrap(),
+                $sequence->toList(),
+                $sequence
+                    ->toIdentity()
+                    ->unwrap()
+                    ->toList(),
             );
         },
     );

--- a/src/Identity.php
+++ b/src/Identity.php
@@ -99,6 +99,14 @@ final class Identity
     }
 
     /**
+     * @return Sequence<T>
+     */
+    public function toSequence(): Sequence
+    {
+        return $this->implementation->toSequence();
+    }
+
+    /**
      * @return T
      */
     public function unwrap(): mixed

--- a/src/Identity/Defer.php
+++ b/src/Identity/Defer.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Identity;
+
+use Innmind\Immutable\Identity;
+
+/**
+ * @psalm-immutable
+ * @template T
+ * @implements Implementation<T>
+ */
+final class Defer implements Implementation
+{
+    /** @var callable(): T */
+    private $value;
+    private bool $loaded = false;
+    /** @var ?T */
+    private mixed $computed = null;
+
+    /**
+     * @param callable(): T $value
+     */
+    public function __construct(callable $value)
+    {
+        $this->value = $value;
+    }
+
+    public function map(callable $map): self
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return new self(fn() => $map($this->load()));
+    }
+
+    public function flatMap(callable $map): Identity
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return Identity::lazy(fn() => $map($this->load())->unwrap());
+    }
+
+    public function unwrap(): mixed
+    {
+        return $this->load();
+    }
+
+    /**
+     * @return T
+     */
+    private function load(): mixed
+    {
+        if ($this->loaded) {
+            /** @var T */
+            return $this->computed;
+        }
+
+        /**
+         * @psalm-suppress InaccessibleProperty
+         * @psalm-suppress ImpureFunctionCall
+         */
+        $this->computed = ($this->value)();
+        /** @psalm-suppress InaccessibleProperty */
+        $this->loaded = true;
+
+        return $this->computed;
+    }
+}

--- a/src/Identity/Defer.php
+++ b/src/Identity/Defer.php
@@ -32,30 +32,22 @@ final class Defer implements Implementation
     public function map(callable $map): self
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return new self(fn() => $map($this->load()));
+        return new self(fn() => $map($this->unwrap()));
     }
 
     public function flatMap(callable $map): Identity
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return Identity::lazy(fn() => $map($this->load())->unwrap());
+        return Identity::lazy(fn() => $map($this->unwrap())->unwrap());
     }
 
     public function toSequence(): Sequence
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return Sequence::defer((fn() => yield $this->load())());
+        return Sequence::defer((fn() => yield $this->unwrap())());
     }
 
     public function unwrap(): mixed
-    {
-        return $this->load();
-    }
-
-    /**
-     * @return T
-     */
-    private function load(): mixed
     {
         if ($this->loaded) {
             /** @var T */

--- a/src/Identity/Defer.php
+++ b/src/Identity/Defer.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\Immutable\Identity;
 
-use Innmind\Immutable\Identity;
+use Innmind\Immutable\{
+    Identity,
+    Sequence,
+};
 
 /**
  * @psalm-immutable
@@ -36,6 +39,12 @@ final class Defer implements Implementation
     {
         /** @psalm-suppress ImpureFunctionCall */
         return Identity::lazy(fn() => $map($this->load())->unwrap());
+    }
+
+    public function toSequence(): Sequence
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return Sequence::defer((fn() => yield $this->load())());
     }
 
     public function unwrap(): mixed

--- a/src/Identity/Implementation.php
+++ b/src/Identity/Implementation.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Identity;
+
+use Innmind\Immutable\Identity;
+
+/**
+ * @psalm-immutable
+ * @template T
+ */
+interface Implementation
+{
+    /**
+     * @template U
+     *
+     * @param callable(T): U $map
+     *
+     * @return self<U>
+     */
+    public function map(callable $map): self;
+
+    /**
+     * @template U
+     *
+     * @param callable(T): Identity<U> $map
+     *
+     * @return Identity<U>
+     */
+    public function flatMap(callable $map): Identity;
+
+    /**
+     * @return T
+     */
+    public function unwrap(): mixed;
+}

--- a/src/Identity/Implementation.php
+++ b/src/Identity/Implementation.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\Immutable\Identity;
 
-use Innmind\Immutable\Identity;
+use Innmind\Immutable\{
+    Identity,
+    Sequence,
+};
 
 /**
  * @psalm-immutable
@@ -28,6 +31,11 @@ interface Implementation
      * @return Identity<U>
      */
     public function flatMap(callable $map): Identity;
+
+    /**
+     * @return Sequence<T>
+     */
+    public function toSequence(): Sequence;
 
     /**
      * @return T

--- a/src/Identity/InMemory.php
+++ b/src/Identity/InMemory.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Identity;
+
+use Innmind\Immutable\Identity;
+
+/**
+ * @psalm-immutable
+ * @template T
+ * @implements Implementation<T>
+ */
+final class InMemory implements Implementation
+{
+    /** @var T */
+    private mixed $value;
+
+    /**
+     * @param T $value
+     */
+    public function __construct(mixed $value)
+    {
+        $this->value = $value;
+    }
+
+    public function map(callable $map): self
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return new self($map($this->value));
+    }
+
+    public function flatMap(callable $map): Identity
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return $map($this->value);
+    }
+
+    public function unwrap(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/src/Identity/InMemory.php
+++ b/src/Identity/InMemory.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Immutable\Identity;
 
 use Innmind\Immutable\Identity;
+use Innmind\Immutable\Sequence;
 
 /**
  * @psalm-immutable
@@ -33,6 +34,11 @@ final class InMemory implements Implementation
     {
         /** @psalm-suppress ImpureFunctionCall */
         return $map($this->value);
+    }
+
+    public function toSequence(): Sequence
+    {
+        return Sequence::of($this->value);
     }
 
     public function unwrap(): mixed

--- a/src/Identity/Lazy.php
+++ b/src/Identity/Lazy.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Identity;
+
+use Innmind\Immutable\Identity;
+
+/**
+ * @psalm-immutable
+ * @template T
+ * @implements Implementation<T>
+ */
+final class Lazy implements Implementation
+{
+    /** @var callable(): T */
+    private $value;
+
+    /**
+     * @param callable(): T $value
+     */
+    public function __construct(callable $value)
+    {
+        $this->value = $value;
+    }
+
+    public function map(callable $map): self
+    {
+        $value = $this->value;
+
+        /** @psalm-suppress ImpureFunctionCall */
+        return new self(static fn() => $map($value()));
+    }
+
+    public function flatMap(callable $map): Identity
+    {
+        $value = $this->value;
+
+        /** @psalm-suppress ImpureFunctionCall */
+        return Identity::lazy(static fn() => $map($value())->unwrap());
+    }
+
+    public function unwrap(): mixed
+    {
+        /** @psalm-suppress ImpureFunctionCall */
+        return ($this->value)();
+    }
+}

--- a/src/Identity/Lazy.php
+++ b/src/Identity/Lazy.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\Immutable\Identity;
 
-use Innmind\Immutable\Identity;
+use Innmind\Immutable\{
+    Identity,
+    Sequence,
+};
 
 /**
  * @psalm-immutable
@@ -37,6 +40,11 @@ final class Lazy implements Implementation
 
         /** @psalm-suppress ImpureFunctionCall */
         return Identity::lazy(static fn() => $map($value())->unwrap());
+    }
+
+    public function toSequence(): Sequence
+    {
+        return Sequence::lazy(fn() => yield $this->unwrap());
     }
 
     public function unwrap(): mixed

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -610,7 +610,10 @@ final class Sequence implements \Countable
      */
     public function toIdentity(): Identity
     {
-        return Identity::of($this);
+        return $this
+            ->implementation
+            ->toIdentity()
+            ->map(static fn($implementation) => new self($implementation));
     }
 
     /**

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -10,6 +10,7 @@ use Innmind\Immutable\{
     Maybe,
     Accumulate,
     SideEffect,
+    Identity,
 };
 
 /**
@@ -603,6 +604,12 @@ final class Defer implements Implementation
 
         /** @psalm-suppress ImpureMethodCall */
         return !$this->values->valid();
+    }
+
+    public function toIdentity(): Identity
+    {
+        /** @var Identity<Implementation<T>> */
+        return Identity::defer(fn() => $this);
     }
 
     /**

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -9,6 +9,7 @@ use Innmind\Immutable\{
     Set,
     Maybe,
     SideEffect,
+    Identity,
 };
 
 /**
@@ -284,6 +285,11 @@ interface Implementation extends \Countable
     public function reverse(): self;
 
     public function empty(): bool;
+
+    /**
+     * @return Identity<self<T>>
+     */
+    public function toIdentity(): Identity;
 
     /**
      * @return Sequence<T>

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -10,6 +10,7 @@ use Innmind\Immutable\{
     Maybe,
     SideEffect,
     RegisterCleanup,
+    Identity,
 };
 
 /**
@@ -638,6 +639,12 @@ final class Lazy implements Implementation
     {
         /** @psalm-suppress ImpureMethodCall */
         return !$this->iterator()->valid();
+    }
+
+    public function toIdentity(): Identity
+    {
+        /** @var Identity<Implementation<T>> */
+        return Identity::lazy(fn() => $this);
     }
 
     /**

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -9,6 +9,7 @@ use Innmind\Immutable\{
     Set,
     Maybe,
     SideEffect,
+    Identity,
 };
 
 /**
@@ -446,6 +447,12 @@ final class Primitive implements Implementation
     public function empty(): bool
     {
         return !$this->has(0);
+    }
+
+    public function toIdentity(): Identity
+    {
+        /** @var Identity<Implementation<T>> */
+        return Identity::of($this);
     }
 
     /**


### PR DESCRIPTION
## Problem

When nesting a lazy sequence inside another sequence (such as when building [xml structures](https://github.com/innmind/xml)) the outer sequence needs to be declared lazy explicitly in order for any composition (for example via `flatMap`) to still be lazy.

This becomes problematic as an application becomes larger as one needs to be aware if the input sequence is lazy or not in order to not break the laziness.

## Solution

This PR adds `Identity::lazy()`, `Identity::defer()` and `Identity::toSequence()`.

These methods allow the chaining `Sequence::lazy(T)->toIdentity()->toSequence()` to produce the type `Sequence<Sequence<T>>` with the outer sequence to be lazy as well.

This chaining carry the lazy nature of the input sequence. Of course if the input sequence is in memory or deferred the outer sequence will be as well.

And since the intermediate `Identity` is a monad you can wrap the sequences in any type you want.