### PR TITLE
Add Sequence::chunk()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\Immutable\Sequence::chunk()`
+
 ## 5.8.0 - 2024-06-27
 
 ### Added

--- a/docs/structures/sequence.md
+++ b/docs/structures/sequence.md
@@ -271,6 +271,30 @@ $lines; // ['foo', 'bar', 'baz', '']
 !!! note ""
     The `flatMap` is here in case there is only one chunk in the sequence, in which case the `aggregate` is not called
 
+### `->chunk()`
+
+This is a shortcut over [`aggregate`](#-aggregate). The same example can be shortened:
+
+```php
+// let's pretend this comes from a stream
+$chunks = ['fo', "o\n", 'ba', "r\n", 'ba', "z\n"];
+$lines = Sequence::of(...$chunks)
+    ->map(Str::of(...))
+    ->map(
+        static fn($chunk) => $chunk
+            ->toEncoding(Str\Encoding::ascii)
+            ->split(),
+    )
+    ->chunk(4)
+    ->map(static fn($chars) => $chars->dropEnd(1)) // to remove "\n"
+    ->map(Str::of('')->join(...))
+    ->map(static fn($line) => $line->toString())
+    ->toList();
+$lines; // ['foo', 'bar', 'baz', '']
+```
+
+This better accomodates to the case where the initial `Sequence` only contains a single value.
+
 ### `->indices()`
 
 Create a new sequence of integers representing the indices of the original sequence.

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -751,8 +751,8 @@ final class Sequence implements \Countable
     public function chunk(int $size): self
     {
         return $this
-            ->map(self::of(...))
-            ->aggregate(static fn($a, $b) => match ($a->size()) {
+            ->map(static fn($value) => self::of($value))
+            ->aggregate(static fn(Sequence $a, $b) => match ($a->size()) {
                 $size => self::of($a, $b),
                 default => self::of($a->append($b)),
             });

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -744,6 +744,21 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @param positive-int $size
+     *
+     * @return self<self<T>>
+     */
+    public function chunk(int $size): self
+    {
+        return $this
+            ->map(self::of(...))
+            ->aggregate(static fn($a, $b) => match ($a->size()) {
+                $size => self::of($a, $b),
+                default => self::of($a->append($b)),
+            });
+    }
+
+    /**
      * Force to load all values into memory (only useful for deferred and lazy Sequence)
      *
      * @return self<T>


### PR DESCRIPTION
## Problem

`Sequence::aggregate()` has the implicit problem that it doesn't handle the case where there is only 1 element in the `Sequence`. This result in the `Sequence` to not always contain what the developer think.

## Solution

- Add `Sequence::chunk()`