### PR TITLE
Add `Map::toSequence()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Using `string`s or `int`s as a `Map` key type and then adding keys of different types was throwing an error.
+
 ## 5.9.0 - 2024-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Innmind\Immutable\Map::toSequence()`
+
 ### Fixed
 
 - Using `string`s or `int`s as a `Map` key type and then adding keys of different types was throwing an error.

--- a/docs/structures/map.md
+++ b/docs/structures/map.md
@@ -349,3 +349,17 @@ Return an empty new map of the same type. Useful to avoid to respecify the templ
 $map = Map::of([1, 2], [3, 4]);
 $map->clear()->size(); // 0
 ```
+
+### `->toSequence()`
+
+Returns an unsorted `Sequence` with all value pairs.
+
+```php
+$map = Map::of([1, 2], [3, 4]);
+$map
+    ->toSequence()
+    ->equals(Sequence::of(
+        new Pair(1, 2),
+        new Pair(3, 4),
+    )); // true
+```

--- a/proofs/map.php
+++ b/proofs/map.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\Immutable\Map;
+use Innmind\BlackBox\Set;
+
+return static function() {
+    yield proof(
+        'Map::toSequence()',
+        given(
+            Set\Sequence::of(Set\Type::any()),
+            Set\Sequence::of(Set\Type::any()),
+        ),
+        static function($assert, $keys, $values) {
+            $map = Map::of();
+
+            foreach ($keys as $index => $key) {
+                $map = ($map)($key, $values[$index] ?? null);
+            }
+
+            $assert->true(
+                $map->equals(Map::of(
+                    ...$map
+                        ->toSequence()
+                        ->map(static fn($pair) => [$pair->key(), $pair->value()])
+                        ->toList(),
+                )),
+            );
+        },
+    );
+};

--- a/src/Map.php
+++ b/src/Map.php
@@ -328,4 +328,12 @@ final class Map implements \Countable
             static fn() => false,
         );
     }
+
+    /**
+     * @return Sequence<Pair<T, S>>
+     */
+    public function toSequence(): Sequence
+    {
+        return $this->implementation->toSequence();
+    }
 }

--- a/src/Map/DoubleIndex.php
+++ b/src/Map/DoubleIndex.php
@@ -302,6 +302,11 @@ final class DoubleIndex implements Implementation
         return $this->pairs->find(static fn($pair) => $predicate($pair->key(), $pair->value()));
     }
 
+    public function toSequence(): Sequence
+    {
+        return $this->pairs->toSequence();
+    }
+
     /**
      * @return Map<T, S>
      */

--- a/src/Map/Implementation.php
+++ b/src/Map/Implementation.php
@@ -166,4 +166,9 @@ interface Implementation extends \Countable
      * @return Maybe<Pair<T, S>>
      */
     public function find(callable $predicate): Maybe;
+
+    /**
+     * @return Sequence<Pair<T, S>>
+     */
+    public function toSequence(): Sequence;
 }

--- a/src/Map/ObjectKeys.php
+++ b/src/Map/ObjectKeys.php
@@ -430,6 +430,15 @@ final class ObjectKeys implements Implementation
         return Maybe::nothing();
     }
 
+    public function toSequence(): Sequence
+    {
+        /** @var Sequence<Pair<T, S>> */
+        return $this->reduce(
+            Sequence::of(),
+            static fn(Sequence $pairs, $key, $value) => ($pairs)(new Pair($key, $value)),
+        );
+    }
+
     /**
      * @return Map<T, S>
      */

--- a/src/Map/Primitive.php
+++ b/src/Map/Primitive.php
@@ -47,6 +47,10 @@ final class Primitive implements Implementation
             return (new DoubleIndex)->merge($this)($key, $value);
         }
 
+        if (!\is_string($key) && !\is_int($key)) {
+            return (new DoubleIndex)->merge($this)($key, $value);
+        }
+
         $values = $this->values;
         $values[$key] = $value;
 

--- a/src/Map/Primitive.php
+++ b/src/Map/Primitive.php
@@ -354,6 +354,15 @@ final class Primitive implements Implementation
         return Maybe::nothing();
     }
 
+    public function toSequence(): Sequence
+    {
+        /** @var Sequence<Pair<T, S>> */
+        return $this->reduce(
+            Sequence::of(),
+            static fn(Sequence $pairs, $key, $value) => ($pairs)(new Pair($key, $value)),
+        );
+    }
+
     /**
      * @return Map<T, S>
      */

--- a/src/Map/Uninitialized.php
+++ b/src/Map/Uninitialized.php
@@ -214,6 +214,11 @@ final class Uninitialized implements Implementation
         return Maybe::nothing();
     }
 
+    public function toSequence(): Sequence
+    {
+        return Sequence::of();
+    }
+
     /**
      * @return Map<T, S>
      */


### PR DESCRIPTION
## Request

This will allow to transform `Map`s into non _dictionary_ values. 

One example is an parsing an http response that returns an associative array, validate it as a `Map` and then transform it in a sequence of values (where the key is injected in the parsed value).

## Note

The fix of `Map::put()` was found by the new property written for `Map::toSequence()`