### PR TITLE
Reduce circular dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           extensions: mbstring, intl
           coverage: none
       - name: Composer
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: ${{ matrix.dependencies }}
       - name: BlackBox
@@ -46,7 +46,7 @@ jobs:
           extensions: mbstring, intl
           coverage: xdebug
       - name: Composer
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: ${{ matrix.dependencies }}
       - name: BlackBox
@@ -54,7 +54,7 @@ jobs:
         env:
           ENABLE_COVERAGE: 'true'
           BLACKBOX_SET_SIZE: 1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   psalm:
@@ -72,7 +72,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl
       - name: Composer
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
       - name: Psalm
         run: vendor/bin/psalm --shepherd
   cs:
@@ -90,6 +90,6 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl
       - name: Composer
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
       - name: CS
         run: vendor/bin/php-cs-fixer fix --diff --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Innmind\Immutable\Map::toSequence()`
 
+### Changed
+
+- Use `static` closures as much as possible to reduce the probability of creating circular references by capturing `$this` as it can lead to memory root buffer exhaustion.
+
 ### Fixed
 
 - Using `string`s or `int`s as a `Map` key type and then adding keys of different types was throwing an error.

--- a/proofs/identity.php
+++ b/proofs/identity.php
@@ -181,4 +181,37 @@ return static function() {
             $assert->same(2, $loaded);
         },
     );
+
+    yield proof(
+        'Identity::defer() holds intermediary values',
+        given(
+            Set\Type::any(),
+            Set\Type::any(),
+        ),
+        static function($assert, $value1, $value2) {
+            $m1 = Identity::defer(static function() use ($value1) {
+                static $loaded = false;
+
+                if ($loaded) {
+                    throw new Exception;
+                }
+
+                $loaded = true;
+
+                return $value1;
+            });
+            $m2 = $m1->map(static fn() => $value2);
+
+            $assert->same(
+                $value2,
+                $m2->unwrap(),
+            );
+            $assert->not()->throws(
+                static fn() => $assert->same(
+                    $value1,
+                    $m1->unwrap(),
+                ),
+            );
+        },
+    );
 };

--- a/proofs/maybe.php
+++ b/proofs/maybe.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\Immutable\Maybe;
+use Innmind\BlackBox\Set;
+
+return static function() {
+    yield proof(
+        'Maybe::defer() holds intermediary values',
+        given(
+            Set\Type::any(),
+            Set\Type::any(),
+        ),
+        static function($assert, $value1, $value2) {
+            $m1 = Maybe::defer(static function() use ($value1) {
+                static $loaded = false;
+
+                if ($loaded) {
+                    throw new Exception;
+                }
+
+                $loaded = true;
+
+                return Maybe::just($value1);
+            });
+            $m2 = $m1->map(static fn() => $value2);
+
+            $assert->same(
+                $value2,
+                $m2->match(
+                    static fn($value) => $value,
+                    static fn() => null,
+                ),
+            );
+            $assert->not()->throws(
+                static fn() => $assert->same(
+                    $value1,
+                    $m1->match(
+                        static fn($value) => $value,
+                        static fn() => null,
+                    ),
+                ),
+            );
+        },
+    );
+};

--- a/src/Identity/Defer.php
+++ b/src/Identity/Defer.php
@@ -38,7 +38,7 @@ final class Defer implements Implementation
     public function flatMap(callable $map): Identity
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return Identity::lazy(fn() => $map($this->unwrap())->unwrap());
+        return Identity::defer(fn() => $map($this->unwrap())->unwrap());
     }
 
     public function toSequence(): Sequence

--- a/src/Identity/Lazy.php
+++ b/src/Identity/Lazy.php
@@ -44,7 +44,9 @@ final class Lazy implements Implementation
 
     public function toSequence(): Sequence
     {
-        return Sequence::lazy(fn() => yield $this->unwrap());
+        $value = $this->value;
+
+        return Sequence::lazy(static fn() => yield $value());
     }
 
     public function unwrap(): mixed

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -80,10 +80,12 @@ final class Defer implements Implementation
      */
     public function get(int $index): Maybe
     {
-        return Maybe::defer(function() use ($index) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values, $index) {
             $iteration = 0;
 
-            foreach ($this->values as $value) {
+            foreach ($values as $value) {
                 if ($index === $iteration) {
                     return Maybe::just($value);
                 }
@@ -226,8 +228,10 @@ final class Defer implements Implementation
      */
     public function first(): Maybe
     {
-        return Maybe::defer(function() {
-            foreach ($this->values as $value) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values) {
+            foreach ($values as $value) {
                 return Maybe::just($value);
             }
 
@@ -241,10 +245,12 @@ final class Defer implements Implementation
      */
     public function last(): Maybe
     {
-        return Maybe::defer(function() {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values) {
             $loaded = false;
 
-            foreach ($this->values as $value) {
+            foreach ($values as $value) {
                 $loaded = true;
             }
 
@@ -282,10 +288,12 @@ final class Defer implements Implementation
      */
     public function indexOf($element): Maybe
     {
-        return Maybe::defer(function() use ($element) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values, $element) {
             $index = 0;
 
-            foreach ($this->values as $value) {
+            foreach ($values as $value) {
                 if ($value === $element) {
                     /** @var Maybe<0|positive-int> */
                     return Maybe::just($index);
@@ -646,8 +654,10 @@ final class Defer implements Implementation
 
     public function find(callable $predicate): Maybe
     {
-        return Maybe::defer(function() use ($predicate) {
-            foreach ($this->values as $value) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values, $predicate) {
+            foreach ($values as $value) {
                 /** @psalm-suppress ImpureFunctionCall */
                 if ($predicate($value) === true) {
                     return Maybe::just($value);

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -86,10 +86,12 @@ final class Lazy implements Implementation
      */
     public function get(int $index): Maybe
     {
-        return Maybe::defer(function() use ($index) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values, $index) {
             $iteration = 0;
             $register = RegisterCleanup::noop();
-            $generator = ($this->values)($register);
+            $generator = $values($register);
 
             foreach ($generator as $value) {
                 if ($index === $iteration) {
@@ -244,10 +246,15 @@ final class Lazy implements Implementation
      */
     public function last(): Maybe
     {
-        return Maybe::defer(function() {
-            $loaded = false;
+        $values = $this->values;
 
-            foreach ($this->iterator() as $value) {
+        return Maybe::defer(static function() use ($values) {
+            $loaded = false;
+            // No-op as we iterate over the whole iterator so the default
+            // cleanup defined in the callable will be called.
+            $register = RegisterCleanup::noop();
+
+            foreach ($values($register) as $value) {
                 $loaded = true;
             }
 
@@ -293,10 +300,12 @@ final class Lazy implements Implementation
      */
     public function indexOf($element): Maybe
     {
-        return Maybe::defer(function() use ($element) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values, $element) {
             $index = 0;
             $register = RegisterCleanup::noop();
-            $generator = ($this->values)($register);
+            $generator = $values($register);
 
             foreach ($generator as $value) {
                 if ($value === $element) {
@@ -681,9 +690,11 @@ final class Lazy implements Implementation
 
     public function find(callable $predicate): Maybe
     {
-        return Maybe::defer(function() use ($predicate) {
+        $values = $this->values;
+
+        return Maybe::defer(static function() use ($values, $predicate) {
             $register = RegisterCleanup::noop();
-            $generator = ($this->values)($register);
+            $generator = $values($register);
 
             foreach ($generator as $value) {
                 /** @psalm-suppress ImpureFunctionCall */
@@ -773,8 +784,11 @@ final class Lazy implements Implementation
      */
     public function aggregate(callable $map, callable $exfiltrate): self
     {
-        return new self(function(RegisterCleanup $registerCleanup) use ($map, $exfiltrate) {
-            $aggregate = new Aggregate($this->iterator());
+        $values = $this->values;
+
+        return new self(static function(RegisterCleanup $registerCleanup) use ($values, $map, $exfiltrate) {
+            $noop = RegisterCleanup::noop();
+            $aggregate = new Aggregate($values($noop));
             /** @psalm-suppress MixedArgument */
             $values = $aggregate(static fn($a, $b) => self::open(
                 $exfiltrate($map($a, $b)),
@@ -802,10 +816,12 @@ final class Lazy implements Implementation
      */
     public function dropWhile(callable $condition): self
     {
+        $values = $this->values;
+
         /** @psalm-suppress ImpureFunctionCall */
-        return new self(function(RegisterCleanup $registerCleanup) use ($condition) {
+        return new self(static function(RegisterCleanup $registerCleanup) use ($values, $condition) {
             /** @psalm-suppress ImpureFunctionCall */
-            $generator = ($this->values)($registerCleanup);
+            $generator = $values($registerCleanup);
 
             /** @psalm-suppress ImpureMethodCall */
             while ($generator->valid()) {


### PR DESCRIPTION
## Problem

Same as https://github.com/Innmind/framework/pull/3

## Solution

Same as https://github.com/Innmind/framework/pull/3 for lazy monads.

For deferred monads we capture a weak reference to `$this` and the `callable` that will generate the value. At unwrap time if the weak reference still holds a value then the user still holds a reference to the monad so we call the unwrap method on it so both the initial value is memoized and the mapped value where we unwrap. If it doesn't contain a value it means the monad was freed from memory and so there's no need to store the intermediary value, we can call the `callable` to generate the value.