### PR TITLE
Improve deferred sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Use `static` closures as much as possible to reduce the probability of creating circular references by capturing `$this` as it can lead to memory root buffer exhaustion.
+- Remove keeping intermediary values of a deferred `Sequence` that is referenced by no one.
 
 ### Fixed
 

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -97,4 +97,46 @@ return static function() {
             );
         },
     );
+
+    yield proof(
+        'Sequende::defer() holds intermediary values even when no longer used',
+        given(
+            Set\Sequence::of(Set\Type::any()),
+            Set\Sequence::of(Set\Type::any()),
+        ),
+        static function($assert, $prefix, $suffix) {
+            $initial = Sequence::defer((static function() use ($prefix, $suffix) {
+                foreach ($prefix as $value) {
+                    yield $value;
+                }
+
+                foreach ($suffix as $value) {
+                    yield $value;
+                }
+            })());
+
+            // This does a partial read on the generator
+            $assert->same(
+                $prefix,
+                $initial
+                    ->take(\count($prefix))
+                    ->toList(),
+            );
+
+            // The maps are only here to wrap the generator, it doesn't change
+            // the values
+            $another = $initial
+                ->map(static fn($value) => [$value])
+                ->map(static fn($values) => $values[0]);
+            unset($initial);
+
+            // If it didn't store the intermediary values the array would miss
+            // the prefix values due to the partial read on the initial
+            // generator due to the ->take()->toList() call above
+            $assert->same(
+                [...$prefix, ...$suffix],
+                $another->toList(),
+            );
+        },
+    );
 };

--- a/src/Accumulate.php
+++ b/src/Accumulate.php
@@ -18,6 +18,7 @@ final class Accumulate implements \Iterator
     private \Generator $generator;
     /** @var list<S> */
     private array $values = [];
+    private bool $started = false;
 
     /**
      * @param \Generator<S> $generator
@@ -32,6 +33,8 @@ final class Accumulate implements \Iterator
      */
     public function current(): mixed
     {
+        /** @psalm-suppress InaccessibleProperty */
+        $this->started = true;
         /** @psalm-suppress UnusedMethodCall */
         $this->pop();
 
@@ -43,6 +46,8 @@ final class Accumulate implements \Iterator
      */
     public function key(): ?int
     {
+        /** @psalm-suppress InaccessibleProperty */
+        $this->started = true;
         /** @psalm-suppress UnusedMethodCall */
         $this->pop();
 
@@ -51,6 +56,8 @@ final class Accumulate implements \Iterator
 
     public function next(): void
     {
+        /** @psalm-suppress InaccessibleProperty */
+        $this->started = true;
         /** @psalm-suppress InaccessibleProperty */
         \next($this->values);
 
@@ -63,11 +70,15 @@ final class Accumulate implements \Iterator
     public function rewind(): void
     {
         /** @psalm-suppress InaccessibleProperty */
+        $this->started = true;
+        /** @psalm-suppress InaccessibleProperty */
         \reset($this->values);
     }
 
     public function valid(): bool
     {
+        /** @psalm-suppress InaccessibleProperty */
+        $this->started = true;
         /** @psalm-suppress ImpureMethodCall */
         $valid = !$this->reachedCacheEnd() || $this->generator->valid();
 
@@ -79,6 +90,11 @@ final class Accumulate implements \Iterator
         }
 
         return $valid;
+    }
+
+    public function started(): bool
+    {
+        return $this->started;
     }
 
     private function reachedCacheEnd(): bool

--- a/src/Accumulate.php
+++ b/src/Accumulate.php
@@ -7,23 +7,20 @@ namespace Innmind\Immutable;
  * Simple iterator to cache the results of a generator so it can be iterated
  * over multiple times
  *
- * @template T
  * @template S
- * @implements \Iterator<T, S>
+ * @implements \Iterator<S>
  * @internal Do not use this in your code
  * @psalm-immutable Not really immutable but to simplify declaring immutability of other structures
  */
 final class Accumulate implements \Iterator
 {
-    /** @var \Generator<T, S> */
+    /** @var \Generator<S> */
     private \Generator $generator;
-    /** @var list<T> */
-    private array $keys = [];
     /** @var list<S> */
     private array $values = [];
 
     /**
-     * @param \Generator<T, S> $generator
+     * @param \Generator<S> $generator
      */
     public function __construct(\Generator $generator)
     {
@@ -42,20 +39,18 @@ final class Accumulate implements \Iterator
     }
 
     /**
-     * @return T
+     * @return int<0, max>|null
      */
-    public function key(): mixed
+    public function key(): ?int
     {
         /** @psalm-suppress UnusedMethodCall */
         $this->pop();
 
-        return \current($this->keys);
+        return \key($this->values);
     }
 
     public function next(): void
     {
-        /** @psalm-suppress InaccessibleProperty */
-        \next($this->keys);
         /** @psalm-suppress InaccessibleProperty */
         \next($this->values);
 
@@ -67,8 +62,6 @@ final class Accumulate implements \Iterator
 
     public function rewind(): void
     {
-        /** @psalm-suppress InaccessibleProperty */
-        \reset($this->keys);
         /** @psalm-suppress InaccessibleProperty */
         \reset($this->values);
     }
@@ -96,11 +89,6 @@ final class Accumulate implements \Iterator
     private function pop(): void
     {
         if ($this->reachedCacheEnd()) {
-            /**
-             * @psalm-suppress InaccessibleProperty
-             * @psalm-suppress ImpureMethodCall
-             */
-            $this->keys[] = $this->generator->key();
             /**
              * @psalm-suppress InaccessibleProperty
              * @psalm-suppress ImpureMethodCall

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -20,8 +20,10 @@ use Innmind\Immutable\{
  */
 final class Defer implements Implementation
 {
-    /** @var \Iterator<T> */
-    private \Iterator $values;
+    /** @var Accumulate<T> */
+    private Accumulate $values;
+    /** @var \Generator<T> */
+    private \Generator $generator;
 
     /**
      * @param \Generator<T> $generator
@@ -37,6 +39,7 @@ final class Defer implements Implementation
                 yield $value;
             }
         })($generator));
+        $this->generator = $generator;
     }
 
     /**
@@ -46,16 +49,20 @@ final class Defer implements Implementation
      */
     public function __invoke($element): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, mixed $element): \Generator {
+            (static function(mixed $element) use ($captured): \Generator {
+                $values = self::detonate($captured);
+
                 /** @var T $value */
                 foreach ($values as $value) {
                     yield $value;
                 }
 
                 yield $element;
-            })($this->values, $element),
+            })($element),
         );
     }
 
@@ -82,10 +89,12 @@ final class Defer implements Implementation
      */
     public function get(int $index): Maybe
     {
-        $values = $this->values;
+        $captured = $this->capture();
 
-        return Maybe::defer(static function() use ($values, $index) {
+        return Maybe::defer(static function() use ($captured, $index) {
             $iteration = 0;
+            /** @var \Iterator<T> */
+            $values = self::detonate($captured);
 
             foreach ($values as $value) {
                 if ($index === $iteration) {
@@ -118,13 +127,16 @@ final class Defer implements Implementation
      */
     public function distinct(): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values): \Generator {
+            (static function() use ($captured): \Generator {
                 /** @var list<T> */
                 $uniques = [];
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     if (!\in_array($value, $uniques, true)) {
                         $uniques[] = $value;
@@ -132,7 +144,7 @@ final class Defer implements Implementation
                         yield $value;
                     }
                 }
-            })($this->values),
+            })(),
         );
     }
 
@@ -141,12 +153,15 @@ final class Defer implements Implementation
      */
     public function drop(int $size): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, int $toDrop): \Generator {
+            (static function(int $toDrop) use ($captured): \Generator {
                 $dropped = 0;
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     if ($dropped < $toDrop) {
                         ++$dropped;
@@ -156,7 +171,7 @@ final class Defer implements Implementation
 
                     yield $value;
                 }
-            })($this->values, $size),
+            })($size),
         );
     }
 
@@ -187,16 +202,20 @@ final class Defer implements Implementation
      */
     public function filter(callable $predicate): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, callable $predicate): \Generator {
-                /** @var T $value */
+            (static function(callable $predicate) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     if ($predicate($value)) {
                         yield $value;
                     }
                 }
-            })($this->values, $predicate),
+            })($predicate),
         );
     }
 
@@ -230,9 +249,12 @@ final class Defer implements Implementation
      */
     public function first(): Maybe
     {
-        $values = $this->values;
+        $captured = $this->capture();
 
-        return Maybe::defer(static function() use ($values) {
+        return Maybe::defer(static function() use ($captured) {
+            /** @var \Iterator<T> */
+            $values = self::detonate($captured);
+
             foreach ($values as $value) {
                 return Maybe::just($value);
             }
@@ -247,10 +269,12 @@ final class Defer implements Implementation
      */
     public function last(): Maybe
     {
-        $values = $this->values;
+        $captured = $this->capture();
 
-        return Maybe::defer(static function() use ($values) {
+        return Maybe::defer(static function() use ($captured) {
             $loaded = false;
+            /** @var \Iterator<T> */
+            $values = self::detonate($captured);
 
             foreach ($values as $value) {
                 $loaded = true;
@@ -290,10 +314,12 @@ final class Defer implements Implementation
      */
     public function indexOf($element): Maybe
     {
-        $values = $this->values;
+        $captured = $this->capture();
 
-        return Maybe::defer(static function() use ($values, $element) {
+        return Maybe::defer(static function() use ($captured, $element) {
             $index = 0;
+            /** @var \Iterator<T> */
+            $values = self::detonate($captured);
 
             foreach ($values as $value) {
                 if ($value === $element) {
@@ -316,18 +342,22 @@ final class Defer implements Implementation
      */
     public function indices(): Implementation
     {
+        $captured = $this->capture();
+
         /**
          * @psalm-suppress ImpureFunctionCall
          * @var Implementation<0|positive-int>
          */
         return new self(
-            (static function(\Iterator $values): \Generator {
+            (static function() use ($captured): \Generator {
                 $index = 0;
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
                 foreach ($values as $_) {
                     yield $index++;
                 }
-            })($this->values),
+            })(),
         );
     }
 
@@ -340,14 +370,18 @@ final class Defer implements Implementation
      */
     public function map(callable $function): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, callable $map): \Generator {
-                /** @var T $value */
+            (static function(callable $map) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     yield $map($value);
                 }
-            })($this->values, $function),
+            })($function),
         );
     }
 
@@ -362,10 +396,14 @@ final class Defer implements Implementation
      */
     public function flatMap(callable $map, callable $exfiltrate): self
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, callable $map, callable $exfiltrate): \Generator {
-                /** @var T $value */
+            (static function(callable $map, callable $exfiltrate) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     /**
                      * @var callable(T): C $map
@@ -375,7 +413,7 @@ final class Defer implements Implementation
                         yield $inner;
                     }
                 }
-            })($this->values, $map, $exfiltrate),
+            })($map, $exfiltrate),
         );
     }
 
@@ -386,10 +424,14 @@ final class Defer implements Implementation
      */
     public function pad(int $size, $element): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, int $toPad, mixed $element): \Generator {
-                /** @var T $value */
+            (static function(int $toPad, mixed $element) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     yield $value;
                     --$toPad;
@@ -399,7 +441,7 @@ final class Defer implements Implementation
                     yield $element;
                     --$toPad;
                 }
-            })($this->values, $size, $element),
+            })($size, $element),
         );
     }
 
@@ -419,12 +461,15 @@ final class Defer implements Implementation
      */
     public function slice(int $from, int $until): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, int $from, int $until): \Generator {
+            (static function(int $from, int $until) use ($captured): \Generator {
                 $index = 0;
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     if ($index >= $from && $index < $until) {
                         yield $value;
@@ -432,7 +477,7 @@ final class Defer implements Implementation
 
                     ++$index;
                 }
-            })($this->values, $from, $until),
+            })($from, $until),
         );
     }
 
@@ -441,12 +486,15 @@ final class Defer implements Implementation
      */
     public function take(int $size): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, int $size): \Generator {
+            (static function(int $size) use ($captured): \Generator {
                 $taken = 0;
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     if ($taken >= $size) {
                         return;
@@ -455,7 +503,7 @@ final class Defer implements Implementation
                     yield $value;
                     ++$taken;
                 }
-            })($this->values, $size),
+            })($size),
         );
     }
 
@@ -478,10 +526,14 @@ final class Defer implements Implementation
      */
     public function append(Implementation $sequence): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, Implementation $sequence): \Generator {
-                /** @var T $value */
+            (static function(Implementation $sequence) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     yield $value;
                 }
@@ -490,7 +542,7 @@ final class Defer implements Implementation
                 foreach ($sequence->iterator() as $value) {
                     yield $value;
                 }
-            })($this->values, $sequence),
+            })($sequence),
         );
     }
 
@@ -501,19 +553,23 @@ final class Defer implements Implementation
      */
     public function prepend(Implementation $sequence): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, Implementation $sequence): \Generator {
+            (static function(Implementation $sequence) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 /** @var T $value */
                 foreach ($sequence->iterator() as $value) {
                     yield $value;
                 }
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     yield $value;
                 }
-            })($this->values, $sequence),
+            })($sequence),
         );
     }
 
@@ -537,14 +593,17 @@ final class Defer implements Implementation
      */
     public function sort(callable $function): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, callable $function): \Generator {
+            (static function(callable $function) use ($captured): \Generator {
                 /** @var callable(T, T): int $sorter */
                 $sorter = $function;
                 $loaded = [];
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     $loaded[] = $value;
                 }
@@ -554,7 +613,7 @@ final class Defer implements Implementation
                 foreach ($loaded as $value) {
                     yield $value;
                 }
-            })($this->values, $function),
+            })($function),
         );
     }
 
@@ -590,12 +649,15 @@ final class Defer implements Implementation
      */
     public function reverse(): Implementation
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values): \Generator {
+            (static function() use ($captured): \Generator {
                 $reversed = [];
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
 
-                /** @var T $value */
                 foreach ($values as $value) {
                     \array_unshift($reversed, $value);
                 }
@@ -603,7 +665,7 @@ final class Defer implements Implementation
                 foreach ($reversed as $value) {
                     yield $value;
                 }
-            })($this->values),
+            })(),
         );
     }
 
@@ -627,14 +689,18 @@ final class Defer implements Implementation
      */
     public function toSequence(): Sequence
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return Sequence::defer(
-            (static function(\Iterator $values): \Generator {
-                /** @var T $value */
+            (static function() use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     yield $value;
                 }
-            })($this->values),
+            })(),
         );
     }
 
@@ -643,22 +709,29 @@ final class Defer implements Implementation
      */
     public function toSet(): Set
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return Set::defer(
-            (static function(\Iterator $values): \Generator {
-                /** @var T $value */
+            (static function() use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     yield $value;
                 }
-            })($this->values),
+            })(),
         );
     }
 
     public function find(callable $predicate): Maybe
     {
-        $values = $this->values;
+        $captured = $this->capture();
 
-        return Maybe::defer(static function() use ($values, $predicate) {
+        return Maybe::defer(static function() use ($captured, $predicate) {
+            /** @var \Iterator<T> */
+            $values = self::detonate($captured);
+
             foreach ($values as $value) {
                 /** @psalm-suppress ImpureFunctionCall */
                 if ($predicate($value) === true) {
@@ -691,13 +764,17 @@ final class Defer implements Implementation
      */
     public function zip(Implementation $sequence): Implementation
     {
+        $captured = $this->capture();
+
         /**
          * @psalm-suppress ImpureFunctionCall
          * @var Implementation<array{T, S}>
          */
         return new self(
-            (static function(\Iterator $self, \Iterator $other) {
+            (static function(\Iterator $other) use ($captured) {
                 /** @var \Iterator<T> $self */
+                $self = self::detonate($captured);
+
                 foreach ($self as $value) {
                     if (!$other->valid()) {
                         return;
@@ -706,7 +783,7 @@ final class Defer implements Implementation
                     yield [$value, $other->current()];
                     $other->next();
                 }
-            })($this->values, $sequence->iterator()),
+            })($sequence->iterator()),
         );
     }
 
@@ -719,17 +796,21 @@ final class Defer implements Implementation
      */
     public function safeguard($carry, callable $assert): self
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, mixed $carry, callable $assert): \Generator {
-                /** @var T $value */
+            (static function(mixed $carry, callable $assert) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     /** @var R */
                     $carry = $assert($carry, $value);
 
                     yield $value;
                 }
-            })($this->values, $carry, $assert),
+            })($carry, $assert),
         );
     }
 
@@ -764,8 +845,13 @@ final class Defer implements Implementation
      */
     public function dropWhile(callable $condition): self
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
-        return new self((static function(\Iterator $values, callable $condition) {
+        return new self((static function(callable $condition) use ($captured) {
+            /** @var \Iterator<T> */
+            $values = self::detonate($captured);
+
             /** @psalm-suppress ImpureMethodCall */
             while ($values->valid()) {
                 /**
@@ -792,7 +878,7 @@ final class Defer implements Implementation
                 /** @psalm-suppress ImpureMethodCall */
                 $values->next();
             }
-        })($this->values, $condition));
+        })($condition));
     }
 
     /**
@@ -802,10 +888,14 @@ final class Defer implements Implementation
      */
     public function takeWhile(callable $condition): self
     {
+        $captured = $this->capture();
+
         /** @psalm-suppress ImpureFunctionCall */
         return new self(
-            (static function(\Iterator $values, callable $condition): \Generator {
-                /** @var T $value */
+            (static function(callable $condition) use ($captured): \Generator {
+                /** @var \Iterator<T> */
+                $values = self::detonate($captured);
+
                 foreach ($values as $value) {
                     if (!$condition($value)) {
                         return;
@@ -813,7 +903,7 @@ final class Defer implements Implementation
 
                     yield $value;
                 }
-            })($this->values, $condition),
+            })($condition),
         );
     }
 
@@ -829,5 +919,39 @@ final class Defer implements Implementation
         }
 
         return new Primitive($values);
+    }
+
+    /**
+     * @return array{\WeakReference<self<T>>, \Iterator<T>}
+     */
+    private function capture(): array
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        return [
+            \WeakReference::create($this),
+            match ($this->values->started()) {
+                true => $this->values,
+                false => $this->generator,
+            },
+        ];
+    }
+
+    /**
+     * @template V
+     *
+     * @param array{\WeakReference<self<V>>, \Iterator<V>} $captured
+     *
+     * @return \Iterator<V>
+     */
+    private static function detonate(array $captured): \Iterator
+    {
+        [$ref, $generator] = $captured;
+        $self = $ref->get();
+
+        if (\is_null($self)) {
+            return $generator;
+        }
+
+        return $self->values;
     }
 }

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -68,7 +68,7 @@ final class Defer implements Implementation
 
     public function size(): int
     {
-        return $this->load()->size();
+        return $this->memoize()->size();
     }
 
     public function count(): int
@@ -184,7 +184,7 @@ final class Defer implements Implementation
     {
         // this cannot be optimised as the whole generator needs to be loaded
         // in order to know the elements to drop
-        return $this->load()->dropEnd($size);
+        return $this->memoize()->dropEnd($size);
     }
 
     /**
@@ -192,7 +192,7 @@ final class Defer implements Implementation
      */
     public function equals(Implementation $sequence): bool
     {
-        return $this->load()->equals($sequence);
+        return $this->memoize()->equals($sequence);
     }
 
     /**
@@ -241,7 +241,7 @@ final class Defer implements Implementation
     public function groupBy(callable $discriminator): Map
     {
         /** @var Map<D, Sequence<T>> */
-        return $this->load()->groupBy($discriminator);
+        return $this->memoize()->groupBy($discriminator);
     }
 
     /**
@@ -453,7 +453,7 @@ final class Defer implements Implementation
     public function partition(callable $predicate): Map
     {
         /** @var Map<bool, Sequence<T>> */
-        return $this->load()->partition($predicate);
+        return $this->memoize()->partition($predicate);
     }
 
     /**
@@ -516,7 +516,7 @@ final class Defer implements Implementation
     {
         // this cannot be optimised as the whole generator needs to be loaded
         // in order to know the elements to drop
-        return $this->load()->takeEnd($size);
+        return $this->memoize()->takeEnd($size);
     }
 
     /**
@@ -835,7 +835,13 @@ final class Defer implements Implementation
      */
     public function memoize(): Implementation
     {
-        return $this->load();
+        $values = [];
+
+        foreach ($this->values as $value) {
+            $values[] = $value;
+        }
+
+        return new Primitive($values);
     }
 
     /**
@@ -905,20 +911,6 @@ final class Defer implements Implementation
                 }
             })($condition),
         );
-    }
-
-    /**
-     * @return Implementation<T>
-     */
-    private function load(): Implementation
-    {
-        $values = [];
-
-        foreach ($this->values as $value) {
-            $values[] = $value;
-        }
-
-        return new Primitive($values);
     }
 
     /**

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -20,14 +20,16 @@ use Innmind\Immutable\{
  */
 final class Defer implements Implementation
 {
-    /** @var \Iterator<int, T> */
+    /** @var \Iterator<T> */
     private \Iterator $values;
 
+    /**
+     * @param \Generator<T> $generator
+     */
     public function __construct(\Generator $generator)
     {
         /**
          * @psalm-suppress ImpureFunctionCall
-         * @var \Iterator<int, T>
          */
         $this->values = new Accumulate((static function(\Generator $generator): \Generator {
             /** @var T $value */
@@ -68,7 +70,7 @@ final class Defer implements Implementation
     }
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator
     {

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -33,7 +33,7 @@ interface Implementation extends \Countable
     public function size(): int;
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator;
 

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -69,7 +69,7 @@ final class Lazy implements Implementation
     }
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator
     {
@@ -904,7 +904,7 @@ final class Lazy implements Implementation
      *
      * @param Implementation<A> $sequence
      *
-     * @return \Iterator<int, A>
+     * @return \Iterator<A>
      */
     private static function open(
         Implementation $sequence,

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -54,7 +54,7 @@ final class Primitive implements Implementation
     }
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator
     {

--- a/src/Set/Defer.php
+++ b/src/Set/Defer.php
@@ -63,7 +63,7 @@ final class Defer implements Implementation
     }
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator
     {

--- a/src/Set/Implementation.php
+++ b/src/Set/Implementation.php
@@ -32,7 +32,7 @@ interface Implementation extends \Countable
     public function size(): int;
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator;
 

--- a/src/Set/Lazy.php
+++ b/src/Set/Lazy.php
@@ -64,7 +64,7 @@ final class Lazy implements Implementation
     }
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator
     {

--- a/src/Set/Primitive.php
+++ b/src/Set/Primitive.php
@@ -69,7 +69,7 @@ final class Primitive implements Implementation
     }
 
     /**
-     * @return \Iterator<int, T>
+     * @return \Iterator<T>
      */
     public function iterator(): \Iterator
     {


### PR DESCRIPTION
## Problem

For implementation convenience each step of a deferred `Sequence` holds in memory the values generated for its step. This means that the example below will keep in memory the arrays `[1, 2, 3, 4]`, `[2, 3, 4, 5]` and `[4, 6, 8, 10]` as long as `$sequence` is referenced. 

```php
$sequence = Sequence::defer((static function() {
    yield from [1, 2, 3, 4];
})())
    ->map(static fn($i) => $i + 1)
    ->map(static fn($i) => $i * 2);
$sequence->toList(); // this memoize the values
```

This is wasteful as the first 2 arrays can't be accessed from outside the monad and has no purpose inside the monad.

The more a user compose its sequences the more internal copies it holds.

## Solution

When composing the generators we use the initial generator if nobody references the `Sequence` that points to the generator.

If somebody references the `Sequence` we use the `Accumulate` iterator as the user may need to iterate over the intermediary values.

If the underlying `Generator` has been started we use the `Accumulate` iterator as well in order to have access to the first values produced by the `Generator` (since a `Generator` can't be rewinded).