### PR TITLE
Deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Use `static` closures as much as possible to reduce the probability of creating circular references by capturing `$this` as it can lead to memory root buffer exhaustion.
 - Remove keeping intermediary values of a deferred `Sequence` that is referenced by no one.
 
+### Deprecated
+
+- `Innmind\Immutable\State`
+
 ### Fixed
 
 - Using `string`s or `int`s as a `Map` key type and then adding keys of different types was throwing an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Deprecated
 
 - `Innmind\Immutable\State`
+- `Innmind\Immutable\Fold`
 
 ### Fixed
 

--- a/docs/structures/fold.md
+++ b/docs/structures/fold.md
@@ -1,5 +1,8 @@
 # `Fold`
 
+??? warning "Deprecated"
+    `Fold` is deprecated and will be removed in the next major release.
+
 The `Fold` monad is intented to work with _(infinite) stream of data_ by folding each element to a single value. This monad distinguishes between the type used to fold and the result type, this allows to inform the _stream_ that it's no longer necessary to extract elements as the folding is done.
 
 An example is reading from a socket as it's an infinite stream of strings:
@@ -38,9 +41,6 @@ $fold->match(
 ```
 
 This example will read all lines from the socket until one line contains `quit\n` then the loop will stop and either dump all the lines to the output or `throw new RuntimeException('socket not reachable')`.
-
-??? warning "Deprecated"
-    `Fold` is deprecated and will be removed in the next major release.
 
 ## `::with()`
 

--- a/docs/structures/fold.md
+++ b/docs/structures/fold.md
@@ -39,6 +39,9 @@ $fold->match(
 
 This example will read all lines from the socket until one line contains `quit\n` then the loop will stop and either dump all the lines to the output or `throw new RuntimeException('socket not reachable')`.
 
+??? warning "Deprecated"
+    `Fold` is deprecated and will be removed in the next major release.
+
 ## `::with()`
 
 This named constructor accepts a value with the notion that more elements are necessary to compute a result

--- a/docs/structures/state.md
+++ b/docs/structures/state.md
@@ -4,6 +4,9 @@ The `State` monad allows you to build a set of pure steps to compute a new state
 
 The state and value can be of any type.
 
+??? warning "Deprecated"
+    `State` is deprecated and will be removed in the next major release.
+
 ## `::of()`
 
 ```php

--- a/docs/structures/state.md
+++ b/docs/structures/state.md
@@ -1,11 +1,11 @@
 # `State`
 
+??? warning "Deprecated"
+    `State` is deprecated and will be removed in the next major release.
+
 The `State` monad allows you to build a set of pure steps to compute a new state. Since the initial state is given when all the steps are built it means that all steps are lazy, this use function composition (so everything is kept in memory).
 
 The state and value can be of any type.
-
-??? warning "Deprecated"
-    `State` is deprecated and will be removed in the next major release.
 
 ## `::of()`
 

--- a/src/Fold.php
+++ b/src/Fold.php
@@ -15,6 +15,7 @@ use Innmind\Immutable\Fold\{
  * @template R Result
  * @template C Computation
  * @psalm-immutable
+ * @deprecated
  */
 final class Fold
 {

--- a/src/Fold/Failure.php
+++ b/src/Fold/Failure.php
@@ -16,6 +16,7 @@ use Innmind\Immutable\{
  * @implements Implementation<F1, R1, C1>
  * @psalm-immutable
  * @internal
+ * @psalm-suppress DeprecatedClass
  */
 final class Failure implements Implementation
 {

--- a/src/Fold/Implementation.php
+++ b/src/Fold/Implementation.php
@@ -15,6 +15,7 @@ use Innmind\Immutable\{
  * @template C Computation
  * @psalm-immutable
  * @internal
+ * @psalm-suppress DeprecatedClass
  */
 interface Implementation
 {

--- a/src/Fold/Result.php
+++ b/src/Fold/Result.php
@@ -16,6 +16,7 @@ use Innmind\Immutable\{
  * @implements Implementation<F1, R1, C1>
  * @psalm-immutable
  * @internal
+ * @psalm-suppress DeprecatedClass
  */
 final class Result implements Implementation
 {

--- a/src/Fold/With.php
+++ b/src/Fold/With.php
@@ -16,6 +16,7 @@ use Innmind\Immutable\{
  * @implements Implementation<F1, R1, C1>
  * @psalm-immutable
  * @internal
+ * @psalm-suppress DeprecatedClass
  */
 final class With implements Implementation
 {

--- a/src/State.php
+++ b/src/State.php
@@ -10,6 +10,7 @@ use Innmind\Immutable\State\Result;
  * @template-covariant S
  * @template-covariant T
  * @deprecated
+ * @psalm-suppress DeprecatedClass
  */
 final class State
 {

--- a/src/State.php
+++ b/src/State.php
@@ -9,6 +9,7 @@ use Innmind\Immutable\State\Result;
  * @psalm-immutable
  * @template-covariant S
  * @template-covariant T
+ * @deprecated
  */
 final class State
 {

--- a/src/State/Result.php
+++ b/src/State/Result.php
@@ -7,6 +7,7 @@ namespace Innmind\Immutable\State;
  * @psalm-immutable
  * @template S
  * @template T
+ * @deprecated
  */
 final class Result
 {


### PR DESCRIPTION
`State` was introduced thinking it may have some use in other Innmind abstractions. It has never been used in 3 years. Removing it in the next major will simplify the package maintenance.

`Fold` was introduced to have a stateless approach for reading sockets in [`innmind/io`](https://github.com/Innmind/io/). This experiment turned out to be too complex. The package now favours the use of _frames_.