### PR TITLE
Add workflow to automatically create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --generate-notes


### PR DESCRIPTION
So far the [releases](https://github.com/Innmind/Immutable/releases) were created by hand and the notes were a copy from the `CHANGELOG.md` file.

Now that all work done on this repository is done through Pull Requests the release notes can be automatically generated. This will help users track the changes.

The `CHANGELOG.md` file will continue to exist and updated as a way to keep track of changes outside of GitHub.