### PR TITLE
Fix `Either` and `Maybe` `::memoize()` not loading everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Innmind\Immutable\Maybe::memoize()` and `Innmind\Immutable\Either::memoize()` was only unwrapping the first layer of the monad. It now recursively unwraps until all the deferred monads are memoized.
+
 ## 5.10.0 - 2024-11-09
 
 ### Added

--- a/proofs/either.php
+++ b/proofs/either.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\Immutable\Either;
+use Innmind\BlackBox\Set;
+
+return static function() {
+    yield proof(
+        'Either::memoize() any composition',
+        given(Set\Type::any()->filter(static fn($value) => !\is_null($value))),
+        static function($assert, $value) {
+            $loaded = false;
+            $either = Either::defer(static fn() => Either::right($value))
+                ->flatMap(static function() use ($value, &$loaded) {
+                    return Either::defer(static function() use ($value, &$loaded) {
+                        $loaded = true;
+
+                        return Either::right($value);
+                    });
+                });
+
+            $assert->false($loaded);
+            $either->memoize();
+            $assert->true($loaded);
+        },
+    );
+};

--- a/proofs/maybe.php
+++ b/proofs/maybe.php
@@ -43,4 +43,24 @@ return static function() {
             );
         },
     );
+
+    yield proof(
+        'Maybe::memoize() any composition',
+        given(Set\Type::any()->filter(static fn($value) => !\is_null($value))),
+        static function($assert, $value) {
+            $loaded = false;
+            $maybe = Maybe::defer(static fn() => Maybe::just($value))
+                ->flatMap(static function() use ($value, &$loaded) {
+                    return Maybe::defer(static function() use ($value, &$loaded) {
+                        $loaded = true;
+
+                        return Maybe::just($value);
+                    });
+                });
+
+            $assert->false($loaded);
+            $maybe->memoize();
+            $assert->true($loaded);
+        },
+    );
 };

--- a/src/Either/Defer.php
+++ b/src/Either/Defer.php
@@ -108,7 +108,7 @@ final class Defer implements Implementation
          * @psalm-suppress InaccessibleProperty
          * @psalm-suppress ImpureFunctionCall
          */
-        return $this->value ??= ($this->deferred)();
+        return $this->value ??= ($this->deferred)()->memoize();
     }
 
     /**

--- a/src/Maybe/Defer.php
+++ b/src/Maybe/Defer.php
@@ -107,7 +107,7 @@ final class Defer implements Implementation
          * @psalm-suppress InaccessibleProperty
          * @psalm-suppress ImpureFunctionCall
          */
-        return $this->value ??= ($this->deferred)();
+        return $this->value ??= ($this->deferred)()->memoize();
     }
 
     /**


### PR DESCRIPTION
## Problem

When one creates a deferred `Maybe` and then compose it via a `flatMap` that returns a new deferred `Maybe` this creates internally a deferred monad containing a deferred monad. When the method `memoize` is called on it, it returns the underlying deferred monad. 

This is problematic because the user thinks the whole composition has been memoized and potential IO operations associated with it have been done. But this is not the case.

The same problem happens with `Either`.

## Solution

When `memoize` is called on these monads it recursively `memoize` the underlying monad. This way the recursion stops when a non deferred monad is found.
