### PR TITLE
Add `Sequence::sink()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Innmind\Immutable\Sequence::sink()`
+
 ### Fixed
 
 - `Innmind\Immutable\Maybe::memoize()` and `Innmind\Immutable\Either::memoize()` was only unwrapping the first layer of the monad. It now recursively unwraps until all the deferred monads are memoized.

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -573,6 +573,18 @@ final class Sequence implements \Countable
     }
 
     /**
+     * @template C
+     *
+     * @param C $carry
+     *
+     * @return Sequence\Sink<T, C>
+     */
+    public function sink(mixed $carry): Sequence\Sink
+    {
+        return Sequence\Sink::of($this->implementation, $carry);
+    }
+
+    /**
      * Return a set of the same type but without any value
      *
      * @return self<T>

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -637,6 +637,31 @@ final class Defer implements Implementation
     }
 
     /**
+     * @template I
+     *
+     * @param I $carry
+     * @param callable(I, T, Sink\Continuation<I>): Sink\Continuation<I> $reducer
+     *
+     * @return I
+     */
+    public function sink($carry, callable $reducer): mixed
+    {
+        $continuation = Sink\Continuation::of($carry);
+
+        foreach ($this->values as $value) {
+            /** @psalm-suppress ImpureFunctionCall */
+            $continuation = $reducer($carry, $value, $continuation);
+            $carry = $continuation->unwrap();
+
+            if (!$continuation->shouldContinue()) {
+                return $continuation->unwrap();
+            }
+        }
+
+        return $continuation->unwrap();
+    }
+
+    /**
      * @return Implementation<T>
      */
     public function clear(): Implementation

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -271,6 +271,18 @@ interface Implementation extends \Countable
     public function reduce($carry, callable $reducer);
 
     /**
+     * Reduce the sequence to a single value but stops on the first failure
+     *
+     * @template I
+     *
+     * @param I $carry
+     * @param callable(I, T, Sink\Continuation<I>): Sink\Continuation<I> $reducer
+     *
+     * @return I
+     */
+    public function sink($carry, callable $reducer): mixed;
+
+    /**
      * Return a set of the same type but without any value
      *
      * @return self<T>

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -429,6 +429,31 @@ final class Primitive implements Implementation
     }
 
     /**
+     * @template I
+     *
+     * @param I $carry
+     * @param callable(I, T, Sink\Continuation<I>): Sink\Continuation<I> $reducer
+     *
+     * @return I
+     */
+    public function sink($carry, callable $reducer): mixed
+    {
+        $continuation = Sink\Continuation::of($carry);
+
+        foreach ($this->values as $value) {
+            /** @psalm-suppress ImpureFunctionCall */
+            $continuation = $reducer($carry, $value, $continuation);
+            $carry = $continuation->unwrap();
+
+            if (!$continuation->shouldContinue()) {
+                break;
+            }
+        }
+
+        return $continuation->unwrap();
+    }
+
+    /**
      * @return self<T>
      */
     public function clear(): Implementation

--- a/src/Sequence/Sink.php
+++ b/src/Sequence/Sink.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Sequence;
+
+use Innmind\Immutable\{
+    Maybe,
+    Either,
+};
+
+/**
+ * @template-covariant T
+ * @template-covariant C
+ * @psalm-immutable
+ */
+final class Sink
+{
+    /**
+     * @param Implementation<T> $implementation
+     * @param C $carry
+     */
+    private function __construct(
+        private Implementation $implementation,
+        private mixed $carry,
+    ) {
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     * @template A
+     * @template B
+     *
+     * @param Implementation<A> $implementation
+     * @param B $carry
+     *
+     * @return self<A, B>
+     */
+    public static function of(Implementation $implementation, mixed $carry): self
+    {
+        return new self($implementation, $carry);
+    }
+
+    /**
+     * @param callable(C, T, Sink\Continuation<C>): Sink\Continuation<C> $reducer
+     *
+     * @return C
+     */
+    public function until(callable $reducer): mixed
+    {
+        return $this->implementation->sink(
+            $this->carry,
+            $reducer,
+        );
+    }
+
+    /**
+     * This will consume all the values from the Sequence as long as a value is
+     * contained in the returned Maybe.
+     *
+     * @param callable(C, T): Maybe<C> $reducer
+     *
+     * @return Maybe<C>
+     */
+    public function maybe(callable $reducer): Maybe
+    {
+        return $this->implementation->sink(
+            Maybe::just($this->carry),
+            static function($carry, $value, $continuation) use ($reducer) {
+                /**
+                 * @var Maybe<C> $carry
+                 * @var T $value
+                 */
+
+                /** @psalm-suppress MixedArgument */
+                $maybe = $carry
+                    ->flatMap(static fn($carry) => $reducer($carry, $value))
+                    ->memoize();
+
+                return $maybe->match(
+                    static fn() => $continuation->continue($maybe),
+                    static fn() => $continuation->stop($maybe),
+                );
+            },
+        );
+    }
+
+    /**
+     * This will consume all the values from the Sequence as long as a right
+     * value is contained in the returned Either.
+     *
+     * @template E
+     *
+     * @param callable(C, T): Either<E, C> $reducer
+     *
+     * @return Either<E, C>
+     */
+    public function either(callable $reducer): Either
+    {
+        /** @var Either<E, C>  */
+        $carry = Either::right($this->carry);
+
+        return $this->implementation->sink(
+            $carry,
+            static function($carry, $value, $continuation) use ($reducer) {
+                /**
+                 * @var Either<E, C> $carry
+                 * @var T $value
+                 */
+
+                /** @psalm-suppress MixedArgument */
+                $either = $carry
+                    ->flatMap(static fn($carry) => $reducer($carry, $value))
+                    ->memoize();
+
+                return $either->match(
+                    static fn() => $continuation->continue($either),
+                    static fn() => $continuation->stop($either),
+                );
+            },
+        );
+    }
+}

--- a/src/Sequence/Sink/Continuation.php
+++ b/src/Sequence/Sink/Continuation.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Sequence\Sink;
+
+/**
+ * @template T
+ * @psalm-immutable
+ */
+final class Continuation
+{
+    /**
+     * @param T $carry
+     */
+    private function __construct(
+        private mixed $carry,
+        private bool $continue,
+    ) {
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     * @template A
+     *
+     * @return self<A>
+     */
+    public static function of(mixed $carry): self
+    {
+        return new self($carry, true);
+    }
+
+    /**
+     * @param T $carry
+     *
+     * @return self<T>
+     */
+    public function continue(mixed $carry): self
+    {
+        return new self($carry, true);
+    }
+
+    /**
+     * @param T $carry
+     *
+     * @return self<T>
+     */
+    public function stop(mixed $carry): self
+    {
+        return new self($carry, false);
+    }
+
+    /**
+     * @internal
+     */
+    public function shouldContinue(): bool
+    {
+        return $this->continue;
+    }
+
+    /**
+     * @internal
+     *
+     * @return T
+     */
+    public function unwrap(): mixed
+    {
+        return $this->carry;
+    }
+}


### PR DESCRIPTION
## Request

In many Innmind packages the pattern of reducing a `Sequence` with a carried value of `Maybe` or `Either` is used to iteratively operate IO operations that may fail and return this potential failure. (An example is the creation of a temporary file in `innmind/operating-system`).

The current implementation brings 2 problems:

- the typing of this reducing is annoying because Psalm have a hard time keeping track of types inside the `Maybe`/`Either`
- if the reducing fails it keeps iterating over the source `Sequence` even though it's not used

## Solution

This PR adds a `Sequence::sink()->until()` that is the same as `Sequence::reduce()` except it uses the continuation pattern to know when to stop reducing.

On top of that, `->sink()->maybe()` and `->sink()->either()` are added as shortcuts to imply the continuation from the values contained in the `Maybe`/`Either`.

This should help simplify other packages and their performance.