### PR TITLE
Reuse GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,34 +9,8 @@ jobs:
       scenarii: 20
     secrets: inherit
   coverage:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.2', '8.3']
-        dependency-versions: ['lowest', 'highest']
-    name: 'Coverage'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-          coverage: xdebug
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: BlackBox
-        run: php blackbox.php
-        env:
-          ENABLE_COVERAGE: 'true'
-          BLACKBOX_SET_SIZE: 1
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: innmind/github-workflows/.github/workflows/coverage.yml@main
+    secrets: inherit
   psalm:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,11 @@ jobs:
     uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
     with:
       scenarii: 20
-    secrets: inherit
   coverage:
     uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit
   psalm:
     uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
-    secrets: inherit
   cs:
     uses: innmind/github-workflows/.github/workflows/cs.yml@main
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   blackbox:
-    uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
+    uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml
     with:
       scenarii: 20
     secrets: inherit
   coverage:
-    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
+    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml
     secrets: inherit
   psalm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on: [push]
 jobs:
   blackbox:
     uses: innmind/github-workflows/.github/workflows/black-box.yml@main
+    with:
+      scenarii: 20
     secrets: inherit
-    env:
-      BLACKBOX_SET_SIZE: 20
   coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     secrets: inherit
   coverage:
     uses: innmind/github-workflows/.github/workflows/coverage.yml@main
-    secrets: inherit
   psalm:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   blackbox:
-    uses: innmind/github-workflows/.github/workflows/black-box.yml
+    uses: innmind/github-workflows/.github/workflows/black-box.yml@main
     secrets: inherit
     env:
       BLACKBOX_SET_SIZE: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     secrets: inherit
   coverage:
     uses: innmind/github-workflows/.github/workflows/coverage.yml@main
+    secrets: inherit
   psalm:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   blackbox:
-    uses: innmind/github-workflows/.github/workflows/black-box.yml@main
+    uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
     with:
       scenarii: 20
     secrets: inherit
   coverage:
-    uses: innmind/github-workflows/.github/workflows/coverage.yml@main
+    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit
   psalm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,6 @@ jobs:
     uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
     secrets: inherit
   cs:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.2']
-    name: 'CS'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-      - name: CS
-        run: vendor/bin/php-cs-fixer fix --diff --dry-run
+    uses: innmind/github-workflows/.github/workflows/cs.yml@main
+    with:
+      php-version: '8.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   blackbox:
-    uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml
+    uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
     with:
       scenarii: 20
     secrets: inherit
   coverage:
-    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml
+    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit
   psalm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,8 @@ jobs:
     uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit
   psalm:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.2', '8.3']
-    name: 'Psalm'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-      - name: Psalm
-        run: vendor/bin/psalm --shepherd
+    uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
+    secrets: inherit
   cs:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,30 +4,10 @@ on: [push]
 
 jobs:
   blackbox:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.2', '8.3']
-        dependency-versions: ['lowest', 'highest']
-    name: 'BlackBox'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-          coverage: none
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: BlackBox
-        run: php blackbox.php
-        env:
-          BLACKBOX_SET_SIZE: 20
+    uses: innmind/github-workflows/.github/workflows/black-box.yml
+    secrets: inherit
+    env:
+      BLACKBOX_SET_SIZE: 20
   coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,22 +6,5 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+    uses: innmind/github-workflows/.github/workflows/documentation.yml@main
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,7 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: write
-
 jobs:
   release:
-    name: Create release
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name }}
-        run: |
-          gh release create "$tag" \
-              --repo="$GITHUB_REPOSITORY" \
-              --generate-notes
+    uses: innmind/github-workflows/.github/workflows/release.yml@main
+    secrets: inherit


### PR DESCRIPTION
The goal is to reduce the number of duplicated workflows across all the Innmind packages and to simplify the maintenance when updating actions versions and such.

Since this is the main package used in all other packages it's the first to reuse workflows.