### PR TITLE
Fix loading an extra element when not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- A lazy `Sequence` would load an extra element that is never used when calling `take`
+
 ## 5.11.1 - 2025-01-16
 
 ### Fixed

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -420,9 +420,10 @@ return static function() {
             Set\Sequence::of(Set\Type::any()),
         ),
         static function($assert, $values) {
-            $sequence = Sequence::lazy(function() use ($values) {
+            $sequence = Sequence::lazy(static function() use ($values) {
                 yield from $values;
-                throw new \Exception;
+
+                throw new Exception;
             })->take(\count($values));
 
             $assert->not()->throws(

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -413,4 +413,24 @@ return static function() {
             );
         },
     );
+
+    yield proof(
+        'Sequence::lazy()->take() should not load an extra element',
+        given(
+            Set\Sequence::of(Set\Type::any()),
+        ),
+        static function($assert, $values) {
+            $sequence = Sequence::lazy(function() use ($values) {
+                yield from $values;
+                throw new \Exception;
+            })->take(\count($values));
+
+            $assert->not()->throws(
+                static fn() => $assert->same(
+                    $values,
+                    $sequence->toList(),
+                ),
+            );
+        },
+    );
 };

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -472,6 +472,10 @@ final class Lazy implements Implementation
 
         return new self(
             static function(RegisterCleanup $register) use ($values, $size): \Generator {
+                if ($size === 0) {
+                    return;
+                }
+
                 $taken = 0;
                 // We intercept the registering of the cleanup function here
                 // because this generator can be stopped when we reach the number
@@ -482,15 +486,15 @@ final class Lazy implements Implementation
                 $middleware = $register->push();
 
                 foreach ($values($middleware) as $value) {
+                    yield $value;
+                    ++$taken;
+
                     if ($taken >= $size) {
                         $middleware->cleanup();
                         $register->pop();
 
                         return;
                     }
-
-                    yield $value;
-                    ++$taken;
                 }
             },
         );

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -1336,7 +1336,7 @@ class SequenceTest extends TestCase
         $cleanups = [];
 
         $this->assertSame([1, 2], $sequence->take(2)->toList());
-        $this->assertSame(['child2', 'parent'], $cleanups);
+        $this->assertSame(['child1', 'parent'], $cleanups);
 
         $cleanups = [];
 


### PR DESCRIPTION
## Problem

When using a lazy `Sequence` with a `take` call it would load an extra element from the generator that is never used. 

In most cases this is not very problematic.

But working on https://github.com/Innmind/io/pull/1 it causes problems as it ends up trying to load a value from a stream that is no longer readable and ends up with an error.

## Solution

- Add a pre-condition if the size is `0`
- Stop the generator before loading the next value