### PR TITLE
Deprecate `Sequence::indexOf()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Deprecated
 
 - `Innmind\Immutable\Set::defer()`
+- `Innmind\Immutable\Sequence::indexOf()`
 
 ## 5.13.0 - 2025-03-23
 

--- a/docs/structures/sequence.md
+++ b/docs/structures/sequence.md
@@ -173,6 +173,9 @@ $sequence->indexOf(2); // Maybe::just(1)
 $sequence->indexOf(4); // Maybe::nothing()
 ```
 
+??? warning "Deprecated"
+    This method will be remove in the next major version.
+
 ### `->find()`
 
 Returns a [`Maybe`](maybe.md) object containing the first element that matches the predicate.

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -364,6 +364,8 @@ final class Sequence implements \Countable
     /**
      * Return the index for the given element
      *
+     * @deprecated
+     *
      * @param T $element
      *
      * @return Maybe<0|positive-int>


### PR DESCRIPTION
As it promotes a more imperative style.