### PR TITLE
Fix `Sequence->snap()->toSet()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Sequence->snap()->toSet()` being recursive
+
 ## 5.14.0 - 2025-04-02
 
 ### Added

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -863,4 +863,29 @@ return static function() {
             $assert->same(1, $loaded);
         },
     );
+
+    yield proof(
+        'Sequence->snap()->toSet()',
+        given(
+            Set\Sequence::of(Set\Integers::any()),
+            Set\Elements::of(
+                static fn(array $values) => Sequence::of(...$values),
+                static fn(array $values) => Sequence::defer(
+                    (static fn() => yield from $values)(),
+                ),
+                static fn(array $values) => Sequence::lazy(
+                    static fn() => yield from $values,
+                ),
+            ),
+        ),
+        static function($assert, $values, $build) {
+            $assert->same(
+                \array_unique($values),
+                $build($values)
+                    ->snap()
+                    ->toSet()
+                    ->toList(),
+            );
+        },
+    );
 };

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -935,32 +935,6 @@ final class Defer implements Implementation
     }
 
     /**
-     * @return Sequence<T>
-     */
-    #[\Override]
-    public function toSequence(): Sequence
-    {
-        $captured = $this->capture();
-
-        /** @psalm-suppress ImpureFunctionCall */
-        return Sequence::defer(
-            (static function() use (&$captured): \Generator {
-                /**
-                 * @psalm-suppress PossiblyNullArgument
-                 * @var Iterator<T>
-                 */
-                $values = self::detonate($captured);
-                $values->rewind();
-
-                while ($values->valid()) {
-                    yield $values->current();
-                    $values->next();
-                }
-            })(),
-        );
-    }
-
-    /**
      * @return Set<T>
      */
     #[\Override]
@@ -1226,6 +1200,31 @@ final class Defer implements Implementation
                     $values->next();
                 }
             })($condition),
+        );
+    }
+
+    /**
+     * @return Sequence<T>
+     */
+    private function toSequence(): Sequence
+    {
+        $captured = $this->capture();
+
+        /** @psalm-suppress ImpureFunctionCall */
+        return Sequence::defer(
+            (static function() use (&$captured): \Generator {
+                /**
+                 * @psalm-suppress PossiblyNullArgument
+                 * @var Iterator<T>
+                 */
+                $values = self::detonate($captured);
+                $values->rewind();
+
+                while ($values->valid()) {
+                    yield $values->current();
+                    $values->next();
+                }
+            })(),
         );
     }
 

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -313,11 +313,6 @@ interface Implementation extends \Countable
     public function toIdentity(): Identity;
 
     /**
-     * @return Sequence<T>
-     */
-    public function toSequence(): Sequence;
-
-    /**
      * @return Set<T>
      */
     public function toSet(): Set;

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -867,15 +867,6 @@ final class Lazy implements Implementation
     }
 
     /**
-     * @return Sequence<T>
-     */
-    #[\Override]
-    public function toSequence(): Sequence
-    {
-        return Sequence::lazy($this->values);
-    }
-
-    /**
      * @return Set<T>
      */
     #[\Override]
@@ -1115,6 +1106,14 @@ final class Lazy implements Implementation
                 }
             },
         );
+    }
+
+    /**
+     * @return Sequence<T>
+     */
+    private function toSequence(): Sequence
+    {
+        return Sequence::lazy($this->values);
     }
 
     /**

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -316,7 +316,7 @@ final class Primitive implements Implementation
     public function via(callable $map): Sequence
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return $map($this->toSequence());
+        return $map(Sequence::of(...$this->values));
     }
 
     /**
@@ -543,15 +543,6 @@ final class Primitive implements Implementation
     {
         /** @var Identity<Implementation<T>> */
         return Identity::of($this);
-    }
-
-    /**
-     * @return Sequence<T>
-     */
-    #[\Override]
-    public function toSequence(): Sequence
-    {
-        return Sequence::of(...$this->values);
     }
 
     /**

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -429,7 +429,7 @@ final class Snap implements Implementation
     #[\Override]
     public function toSet(): Set
     {
-        return $this->toSet()->snap();
+        return $this->will->toSet()->snap();
     }
 
     #[\Override]

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -415,15 +415,6 @@ final class Snap implements Implementation
     }
 
     /**
-     * @return Sequence<T>
-     */
-    #[\Override]
-    public function toSequence(): Sequence
-    {
-        return $this->toSequence()->snap();
-    }
-
-    /**
      * @return Set<T>
      */
     #[\Override]

--- a/tests/Sequence/DeferTest.php
+++ b/tests/Sequence/DeferTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Tests\Innmind\Immutable\Sequence;
 
 use Innmind\Immutable\{
+    Sequence,
     Sequence\Defer,
     Sequence\Implementation,
     Map,
@@ -649,7 +650,7 @@ class DeferTest extends TestCase
     public function testReverse()
     {
         $loaded = false;
-        $a = new Defer((static function() use (&$loaded) {
+        $a = Sequence::defer((static function() use (&$loaded) {
             yield from [1, 2];
             yield from [3, 4];
             $loaded = true;
@@ -657,9 +658,9 @@ class DeferTest extends TestCase
         $b = $a->reverse();
 
         $this->assertFalse($loaded);
-        $this->assertSame([1, 2, 3, 4], $a->toSequence()->toList());
-        $this->assertInstanceOf(Defer::class, $b);
-        $this->assertSame([4, 3, 2, 1], \iterator_to_array($b->iterator()));
+        $this->assertSame([1, 2, 3, 4], $a->toList());
+        $this->assertInstanceOf(Sequence::class, $b);
+        $this->assertSame([4, 3, 2, 1], $b->toList());
         $this->assertTrue($loaded);
     }
 

--- a/tests/Sequence/LazyTest.php
+++ b/tests/Sequence/LazyTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Tests\Innmind\Immutable\Sequence;
 
 use Innmind\Immutable\{
+    Sequence,
     Sequence\Lazy,
     Sequence\Implementation,
     Map,
@@ -667,7 +668,7 @@ class LazyTest extends TestCase
     public function testReverse()
     {
         $loaded = false;
-        $a = new Lazy(static function() use (&$loaded) {
+        $a = Sequence::lazy(static function() use (&$loaded) {
             yield from [1, 2];
             yield from [3, 4];
             $loaded = true;
@@ -675,9 +676,9 @@ class LazyTest extends TestCase
         $b = $a->reverse();
 
         $this->assertFalse($loaded);
-        $this->assertSame([1, 2, 3, 4], $a->toSequence()->toList());
-        $this->assertInstanceOf(Lazy::class, $b);
-        $this->assertSame([4, 3, 2, 1], \iterator_to_array($b->iterator()));
+        $this->assertSame([1, 2, 3, 4], $a->toList());
+        $this->assertInstanceOf(Sequence::class, $b);
+        $this->assertSame([4, 3, 2, 1], $b->toList());
         $this->assertTrue($loaded);
     }
 


### PR DESCRIPTION
The `toSet` method was called recursively.

`toSequence` was also affected but since a recent refactoring this interface method is no longer necessary, hence the suppressions.