### PR TITLE
Fix `Sequence::snap()` not keeping intermediary steps in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Sequence->snap()` on an already loaded sequence created useless objects
+
 ## 5.14.1 - 2025-04-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `Sequence->snap()` on an already loaded sequence created useless objects
+- `Sequence->snap()` wasn't keeping intermediary steps in memory
 
 ## 5.14.1 - 2025-04-02
 

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -960,4 +960,27 @@ return static function() {
             );
         },
     );
+
+    yield proof(
+        'Sequence::lazy()->snap()->toSet() only load the generator once',
+        given(
+            Set\Sequence::of(Set\Integers::any()),
+        ),
+        static function($assert, $values) {
+            $loaded = 0;
+            $sequence = Sequence::lazy(static function() use ($values, &$loaded) {
+                yield from $values;
+                ++$loaded;
+            })->snap();
+            $set = $sequence->toSet();
+
+            $assert->same(
+                \array_unique($values),
+                $set->toList(),
+            );
+            $assert->same(1, $loaded);
+            $assert->same($values, $sequence->toList());
+            $assert->same(1, $loaded);
+        },
+    );
 };

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -912,6 +912,31 @@ return static function() {
     );
 
     yield proof(
+        'Sequence::lazy()->snap()->via() loads the initial snapped sequence only once',
+        given(
+            Set\Sequence::of(Set\Type::any()),
+        ),
+        static function($assert, $values) {
+            $loaded = 0;
+            $sequence = Sequence::lazy(
+                static function() use ($values, &$loaded) {
+                    yield from $values;
+                    ++$loaded;
+                },
+            )->snap();
+            $sequence2 = $sequence->via(static fn($sequence) => $sequence);
+
+            $assert->same(0, $loaded);
+            $assert->same($values, $sequence2->toList());
+            $assert->same(1, $loaded);
+            $assert->same($values, $sequence2->toList());
+            $assert->same(1, $loaded);
+            $assert->same($values, $sequence->toList());
+            $assert->same(1, $loaded);
+        },
+    );
+
+    yield proof(
         'Sequence->snap()->toSet()',
         given(
             Set\Sequence::of(Set\Integers::any()),

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -983,4 +983,23 @@ return static function() {
             $assert->same(1, $loaded);
         },
     );
+
+    yield proof(
+        'Sequence::lazy()->snap() should not keep the original sequence when no longer used',
+        given(
+            Set\Sequence::of(Set\Integers::any()),
+        ),
+        static function($assert, $values) {
+            $beacon = new stdClass;
+            $sequence = Sequence::lazy(static function() use ($values, $beacon) {
+                yield from $values;
+            })->snap();
+            $beacon = WeakReference::create($beacon);
+
+            $assert->object($beacon->get());
+            $assert->same($values, $sequence->toList());
+            $assert->null($beacon->get());
+            $assert->same($values, $sequence->toList());
+        },
+    );
 };

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -425,7 +425,9 @@ final class Sequence implements \Countable
      */
     public function via(callable $map): self
     {
-        return $this->implementation->via($map);
+        return $this->implementation->via(
+            static fn($implementation) => $map(new self($implementation)),
+        );
     }
 
     /**

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -827,6 +827,10 @@ final class Sequence implements \Countable
      */
     public function snap(): self
     {
+        if ($this->implementation instanceof Sequence\Primitive) {
+            return $this;
+        }
+
         return new self(new Sequence\Snap($this->implementation));
     }
 }

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -1103,10 +1103,10 @@ final class Defer implements Implementation
     }
 
     /**
-     * @return Implementation<T>
+     * @return Primitive<T>
      */
     #[\Override]
-    public function memoize(): Implementation
+    public function memoize(): Primitive
     {
         $values = [];
         $this->values->rewind();

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -534,18 +534,18 @@ final class Defer implements Implementation
     /**
      * @template S
      *
-     * @param callable(Sequence<T>): Sequence<S> $map
+     * @param callable(Implementation<T>): Sequence<S> $map
      *
      * @return Sequence<S>
      */
     #[\Override]
     public function via(callable $map): Sequence
     {
-        $sequence = $this->toSequence();
+        $self = $this;
 
         /** @psalm-suppress ImpureFunctionCall */
-        return Sequence::defer((static function() use ($sequence, $map) {
-            yield $map($sequence);
+        return Sequence::defer((static function() use ($self, $map) {
+            yield $map($self);
         })())->flatMap(static fn($sequence) => $sequence);
     }
 

--- a/src/Sequence/Defer.php
+++ b/src/Sequence/Defer.php
@@ -1204,31 +1204,6 @@ final class Defer implements Implementation
     }
 
     /**
-     * @return Sequence<T>
-     */
-    private function toSequence(): Sequence
-    {
-        $captured = $this->capture();
-
-        /** @psalm-suppress ImpureFunctionCall */
-        return Sequence::defer(
-            (static function() use (&$captured): \Generator {
-                /**
-                 * @psalm-suppress PossiblyNullArgument
-                 * @var Iterator<T>
-                 */
-                $values = self::detonate($captured);
-                $values->rewind();
-
-                while ($values->valid()) {
-                    yield $values->current();
-                    $values->next();
-                }
-            })(),
-        );
-    }
-
-    /**
      * @return array{
      *     Accumulate<T>,
      *     \Generator<int<0, max>, T>,

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -367,9 +367,9 @@ interface Implementation extends \Countable
     public function aggregate(callable $map, callable $exfiltrate): self;
 
     /**
-     * @return self<T>
+     * @return Primitive<T>
      */
-    public function memoize(): self;
+    public function memoize(): Primitive;
 
     /**
      * @param callable(T): bool $condition

--- a/src/Sequence/Implementation.php
+++ b/src/Sequence/Implementation.php
@@ -176,7 +176,7 @@ interface Implementation extends \Countable
     /**
      * @template S
      *
-     * @param callable(Sequence<T>): Sequence<S> $map
+     * @param callable(self<T>): Sequence<S> $map
      *
      * @return Sequence<S>
      */

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -484,17 +484,17 @@ final class Lazy implements Implementation
     /**
      * @template S
      *
-     * @param callable(Sequence<T>): Sequence<S> $map
+     * @param callable(Implementation<T>): Sequence<S> $map
      *
      * @return Sequence<S>
      */
     #[\Override]
     public function via(callable $map): Sequence
     {
-        $sequence = $this->toSequence();
+        $self = $this;
 
-        return Sequence::lazy(static function() use ($sequence, $map) {
-            yield $map($sequence);
+        return Sequence::lazy(static function() use ($self, $map) {
+            yield $map($self);
         })->flatMap(static fn($sequence) => $sequence);
     }
 

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -1109,14 +1109,6 @@ final class Lazy implements Implementation
     }
 
     /**
-     * @return Sequence<T>
-     */
-    private function toSequence(): Sequence
-    {
-        return Sequence::lazy($this->values);
-    }
-
-    /**
      * @return Primitive<T>
      */
     private function load(): Primitive

--- a/src/Sequence/Lazy.php
+++ b/src/Sequence/Lazy.php
@@ -1015,10 +1015,10 @@ final class Lazy implements Implementation
     }
 
     /**
-     * @return Implementation<T>
+     * @return Primitive<T>
      */
     #[\Override]
-    public function memoize(): Implementation
+    public function memoize(): Primitive
     {
         return $this->load();
     }
@@ -1117,9 +1117,9 @@ final class Lazy implements Implementation
     }
 
     /**
-     * @return Implementation<T>
+     * @return Primitive<T>
      */
-    private function load(): Implementation
+    private function load(): Primitive
     {
         $values = [];
         $iterator = $this->iterator();

--- a/src/Sequence/Primitive.php
+++ b/src/Sequence/Primitive.php
@@ -308,7 +308,7 @@ final class Primitive implements Implementation
     /**
      * @template S
      *
-     * @param callable(Sequence<T>): Sequence<S> $map
+     * @param callable(Implementation<T>): Sequence<S> $map
      *
      * @return Sequence<S>
      */
@@ -316,7 +316,7 @@ final class Primitive implements Implementation
     public function via(callable $map): Sequence
     {
         /** @psalm-suppress ImpureFunctionCall */
-        return $map(Sequence::of(...$this->values));
+        return $map($this);
     }
 
     /**

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -42,7 +42,7 @@ final class Snap implements Implementation
     #[\Override]
     public function __invoke($element): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence($element));
+        return $this->will(static fn($self) => $self($element));
     }
 
     #[\Override]
@@ -85,7 +85,7 @@ final class Snap implements Implementation
     #[\Override]
     public function diff(Implementation $sequence): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->diff($sequence));
+        return $this->will(static fn($self) => $self->diff($sequence));
     }
 
     /**
@@ -94,7 +94,7 @@ final class Snap implements Implementation
     #[\Override]
     public function distinct(): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->distinct());
+        return $this->will(static fn($self) => $self->distinct());
     }
 
     /**
@@ -105,7 +105,7 @@ final class Snap implements Implementation
     #[\Override]
     public function drop(int $size): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->drop($size));
+        return $this->will(static fn($self) => $self->drop($size));
     }
 
     /**
@@ -116,7 +116,7 @@ final class Snap implements Implementation
     #[\Override]
     public function dropEnd(int $size): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->dropEnd($size));
+        return $this->will(static fn($self) => $self->dropEnd($size));
     }
 
     /**
@@ -136,7 +136,7 @@ final class Snap implements Implementation
     #[\Override]
     public function filter(callable $predicate): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->filter($predicate));
+        return $this->will(static fn($self) => $self->filter($predicate));
     }
 
     /**
@@ -207,7 +207,7 @@ final class Snap implements Implementation
     #[\Override]
     public function indices(): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->indices());
+        return $this->will(static fn($self) => $self->indices());
     }
 
     /**
@@ -220,7 +220,7 @@ final class Snap implements Implementation
     #[\Override]
     public function map(callable $function): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->map($function));
+        return $this->will(static fn($self) => $self->map($function));
     }
 
     /**
@@ -235,7 +235,7 @@ final class Snap implements Implementation
     #[\Override]
     public function flatMap(callable $map, callable $exfiltrate): self
     {
-        return $this->will(static fn($sequence) => $sequence->flatMap($map, $exfiltrate));
+        return $this->will(static fn($self) => $self->flatMap($map, $exfiltrate));
     }
 
     /**
@@ -279,7 +279,7 @@ final class Snap implements Implementation
     #[\Override]
     public function pad(int $size, $element): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->pad($size, $element));
+        return $this->will(static fn($self) => $self->pad($size, $element));
     }
 
     /**
@@ -303,7 +303,7 @@ final class Snap implements Implementation
     #[\Override]
     public function slice(int $from, int $until): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->slice($from, $until));
+        return $this->will(static fn($self) => $self->slice($from, $until));
     }
 
     /**
@@ -314,7 +314,7 @@ final class Snap implements Implementation
     #[\Override]
     public function take(int $size): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->take($size));
+        return $this->will(static fn($self) => $self->take($size));
     }
 
     /**
@@ -325,7 +325,7 @@ final class Snap implements Implementation
     #[\Override]
     public function takeEnd(int $size): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->takeEnd($size));
+        return $this->will(static fn($self) => $self->takeEnd($size));
     }
 
     /**
@@ -336,7 +336,7 @@ final class Snap implements Implementation
     #[\Override]
     public function append(Implementation $sequence): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->append($sequence));
+        return $this->will(static fn($self) => $self->append($sequence));
     }
 
     /**
@@ -347,7 +347,7 @@ final class Snap implements Implementation
     #[\Override]
     public function prepend(Implementation $sequence): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->prepend($sequence));
+        return $this->will(static fn($self) => $self->prepend($sequence));
     }
 
     /**
@@ -358,7 +358,7 @@ final class Snap implements Implementation
     #[\Override]
     public function intersect(Implementation $sequence): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->intersect($sequence));
+        return $this->will(static fn($self) => $self->intersect($sequence));
     }
 
     /**
@@ -369,7 +369,7 @@ final class Snap implements Implementation
     #[\Override]
     public function sort(callable $function): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->sort($function));
+        return $this->will(static fn($self) => $self->sort($function));
     }
 
     /**
@@ -416,7 +416,7 @@ final class Snap implements Implementation
     #[\Override]
     public function reverse(): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->reverse());
+        return $this->will(static fn($self) => $self->reverse());
     }
 
     #[\Override]
@@ -477,7 +477,7 @@ final class Snap implements Implementation
     #[\Override]
     public function zip(Implementation $sequence): self
     {
-        return $this->will(static fn($sequence) => $sequence->zip($sequence));
+        return $this->will(static fn($self) => $self->zip($sequence));
     }
 
     /**
@@ -490,7 +490,7 @@ final class Snap implements Implementation
     #[\Override]
     public function safeguard($carry, callable $assert): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->safeguard($carry, $assert));
+        return $this->will(static fn($self) => $self->safeguard($carry, $assert));
     }
 
     /**
@@ -504,7 +504,7 @@ final class Snap implements Implementation
     #[\Override]
     public function aggregate(callable $map, callable $exfiltrate): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->aggregate($map, $exfiltrate));
+        return $this->will(static fn($self) => $self->aggregate($map, $exfiltrate));
     }
 
     /**
@@ -541,7 +541,7 @@ final class Snap implements Implementation
     #[\Override]
     public function dropWhile(callable $condition): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->dropWhile($condition));
+        return $this->will(static fn($self) => $self->dropWhile($condition));
     }
 
     /**
@@ -552,7 +552,7 @@ final class Snap implements Implementation
     #[\Override]
     public function takeWhile(callable $condition): Implementation
     {
-        return $this->will(static fn($sequence) => $sequence->takeWhile($condition));
+        return $this->will(static fn($self) => $self->takeWhile($condition));
     }
 
     /**

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -433,8 +433,16 @@ final class Snap implements Implementation
     #[\Override]
     public function toSet(): Set
     {
-        // todo fix
-        return $this->implementation->toSet()->snap();
+        $self = $this;
+
+        // By using a lazy Set we're sure that we don't load the data too early.
+        // And the source of the generator is $this, meaning that as soon the
+        // Set starts to load a value it memoize $this (thus loading everything
+        // in memory). And all new iterations over the Set will reuse the
+        // already loaded data.
+        return Set::lazy(static function() use ($self) {
+            yield from $self->iterator();
+        });
     }
 
     #[\Override]

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -524,6 +524,10 @@ final class Snap implements Implementation
         // action on this version.
         /** @psalm-suppress InaccessibleProperty */
         $this->implementation = ($this->will)($this->implementation->memoize());
+        // Overwriting the action here allows to free from memory any variable
+        // captured in the user provided callable.
+        /** @psalm-suppress InaccessibleProperty */
+        $this->will = static fn(Implementation $sequence): Implementation => $sequence;
 
         /** @var Primitive<T> */
         return $this->implementation;

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -433,6 +433,12 @@ final class Snap implements Implementation
     #[\Override]
     public function toSet(): Set
     {
+        // If this snapped version has been loaded then there is no need to go
+        // back to a lazy Set
+        if ($this->implementation instanceof Primitive) {
+            return $this->implementation->toSet();
+        }
+
         $self = $this;
 
         // By using a lazy Set we're sure that we don't load the data too early.

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -250,6 +250,12 @@ final class Snap implements Implementation
     #[\Override]
     public function via(callable $map): Sequence
     {
+        // If this snapped version has been loaded then there is no need to keep
+        // wrapping the new transformations inside a Snap.
+        if ($this->implementation instanceof Primitive) {
+            return $this->implementation->via($map);
+        }
+
         $self = $this;
 
         // $map is not directly called on $this to allow to keep the lazyness or

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -230,10 +230,10 @@ final class Snap implements Implementation
      * @param callable(T): C $map
      * @param callable(C): Implementation<S> $exfiltrate
      *
-     * @return self<S>
+     * @return Implementation<S>
      */
     #[\Override]
-    public function flatMap(callable $map, callable $exfiltrate): self
+    public function flatMap(callable $map, callable $exfiltrate): Implementation
     {
         return $this->will(static fn($self) => $self->flatMap($map, $exfiltrate));
     }
@@ -472,10 +472,10 @@ final class Snap implements Implementation
      *
      * @param Implementation<S> $sequence
      *
-     * @return self<array{T, S}>
+     * @return Implementation<array{T, S}>
      */
     #[\Override]
-    public function zip(Implementation $sequence): self
+    public function zip(Implementation $sequence): Implementation
     {
         return $this->will(static fn($self) => $self->zip($sequence));
     }
@@ -560,10 +560,14 @@ final class Snap implements Implementation
      *
      * @param pure-Closure(Implementation<T>): Implementation<S> $method
      *
-     * @return self<S>
+     * @return Implementation<S>
      */
-    private function will(\Closure $method): self
+    private function will(\Closure $method): Implementation
     {
+        if ($this->implementation instanceof Primitive) {
+            return $method($this->implementation);
+        }
+
         return new self($this, $method);
     }
 }

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -22,7 +22,6 @@ final class Snap implements Implementation
     private Implementation $implementation;
     /** @var pure-Closure(Implementation): Implementation<T> */
     private \Closure $will;
-    private bool $loaded;
 
     /**
      * @param ?pure-Closure(Implementation): Implementation<T> $will
@@ -33,7 +32,6 @@ final class Snap implements Implementation
     ) {
         $this->implementation = $implementation;
         $this->will = $will ?? static fn(Implementation $sequence): Implementation => $sequence;
-        $this->loaded = false;
     }
 
     /**
@@ -510,12 +508,12 @@ final class Snap implements Implementation
     }
 
     /**
-     * @return Implementation<T>
+     * @return Primitive<T>
      */
     #[\Override]
-    public function memoize(): Implementation
+    public function memoize(): Primitive
     {
-        if ($this->loaded) {
+        if ($this->implementation instanceof Primitive) {
             return $this->implementation;
         }
 
@@ -526,9 +524,8 @@ final class Snap implements Implementation
         // action on this version.
         /** @psalm-suppress InaccessibleProperty */
         $this->implementation = ($this->will)($this->implementation->memoize());
-        /** @psalm-suppress InaccessibleProperty */
-        $this->loaded = true;
 
+        /** @var Primitive<T> */
         return $this->implementation;
     }
 


### PR DESCRIPTION
## Problem

When calling `->snap()` on a `Sequence` followed by other method calls, only the last `Sequence` keeps the values in cache. This leads to bugs when comparing lazy sequences.

A simple example is as follow:

```php
$sequence1 = Sequence::lazy(static fn() => yield new stdClass)->snap();
$sequence2 = $sequence1->map(static fn($value) => $value);

$equal = $sequence1->equals($sequence2);
```

The expected behaviour is that `$result === true` but it's `false`. 

What happens is as follows when `equals` is called:

- `$sequence2` calls the generator given to `$sequence1`
- `$sequence2` applies the map callable (which does nothing)
- `$sequence2` keeps in cache the loaded `stdClass` object
- `$sequence1` calls the generator which creates a new `stdClass`
- `$sequence1` keeps in cache the loaded `stdClass` object
- the 2 cached values are compared

But since the generator has been called twice we have 2 different objects instead of one.

When `$sequence2` load its values it should instruct `$sequence1` to also cache its values.

## Solutions

Instead of `Snap` directly applying the transformation (map, flatMap, etc...) on its underlying implementation before re-wrapping it in a `Snap` (thus losing track here of the intermediary step that should be cached), it wraps the current `Snap` in a new `Snap` and stores the transformation in a closure to be applied when the implementation needs to be memoized.

This creates a tree of `Snap` objects alongside the transformation to apply at each step.

When a `Snap` needs to be memoized it recursively call the `->memoize()` method of the underlying implementation. This way we _move down_ to reach the source implementation on which `->snap()` has been called, loads everything in memory and then _move back up_ applying at each recursion level the associated transformation.

During this process the initial implementation inside the `Snap` is replaced by the memoized implementation. This allows to remove any reference underlying transformations. If the user didn't keep any reference to them then it frees them from memory. 

And since this is recursive it will keep only one representation of the data at a time in memory.

---

This also fixes the problem where even if the data has been memoized, new transformations where _lazy_ because it was wrapped in a `Snap`. 

Now it's directly applied.