### PR TITLE
Fix Sequence->snap()->toSet() being lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Sequence->snap()->toSet()` wasn't properly keeping values in memory (transformations were lazy)
+
 ## 5.14.2 - 2025-05-02
 
 ### Fixed

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -1002,4 +1002,22 @@ return static function() {
             $assert->same($values, $sequence->toList());
         },
     );
+
+    yield proof(
+        'Sequence::lazy()->snap()->toSet() should keep values in memory',
+        given(
+            Set\Sequence::of(Set\Integers::any()),
+        ),
+        static function($assert, $values) {
+            $set = Sequence::lazy(static fn() => yield from $values)
+                ->snap()
+                ->toSet()
+                ->map(static fn() => new stdClass);
+
+            $assert->same(
+                $set->toList(),
+                $set->toList(),
+            );
+        },
+    );
 };

--- a/src/Sequence/Snap.php
+++ b/src/Sequence/Snap.php
@@ -452,7 +452,7 @@ final class Snap implements Implementation
         // already loaded data.
         return Set::lazy(static function() use ($self) {
             yield from $self->iterator();
-        });
+        })->snap();
     }
 
     #[\Override]


### PR DESCRIPTION
## Problem 

In #54 the `Sequence->snap()->toSet()` was thought to be safe of using a lazy `Set` as the underlying value was correctly memoized.

The problem is that any transformation applied on it is now lazy. Meaning that if a transformation implies creating an object then these objects are re-created each time.

This is problematic for `formal/orm` as it relies on object identity to know what to persist.

## Solution

`->snap()` is applied on the lazy `Set` to make sure everything is kept in memory.