### PR TITLE
Fix `Set::equals()` loading its data when not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Set::equals()` and `Sequence::equals()` were loading their data when compared to themselves
+
 ## 5.14.3 - 2025-05-02
 
 ### Fixed

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -1020,4 +1020,20 @@ return static function() {
             );
         },
     );
+
+    yield proof(
+        'Sequence::equals() should not load its data when compared to itself',
+        given(Set\Sequence::of(Set\Type::any())),
+        static function($assert, $values) {
+            $loaded = false;
+            $sequence = Sequence::lazy(static function() use (&$loaded, $values) {
+                $loaded = true;
+
+                yield from $values;
+            });
+
+            $assert->true($sequence->equals($sequence));
+            $assert->false($loaded);
+        },
+    );
 };

--- a/proofs/set.php
+++ b/proofs/set.php
@@ -252,4 +252,20 @@ return static function() {
             $assert->same(1, $loaded);
         },
     );
+
+    yield proof(
+        'Set::equals() should not load its data when compared to itself',
+        given(DataSet\Sequence::of(DataSet\Type::any())),
+        static function($assert, $values) {
+            $loaded = false;
+            $set = Set::lazy(static function() use (&$loaded, $values) {
+                $loaded = true;
+
+                yield from $values;
+            });
+
+            $assert->true($set->equals($set));
+            $assert->false($loaded);
+        },
+    );
 };

--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -260,6 +260,12 @@ final class Sequence implements \Countable
      */
     public function equals(self $sequence): bool
     {
+        if ($this === $sequence) {
+            // This avoids loading a lazy/deferred/snapped sequence, as a
+            // Sequence is necessarily equal to itself
+            return true;
+        }
+
         return $this->implementation->equals(
             $sequence->implementation,
         );

--- a/src/Set.php
+++ b/src/Set.php
@@ -248,6 +248,12 @@ final class Set implements \Countable
      */
     public function equals(self $set): bool
     {
+        if ($this === $set) {
+            // This avoids loading a lazy set, as a Set is necessarily equal to
+            // itself
+            return true;
+        }
+
         $size = $this->size();
 
         if ($size !== $set->size()) {


### PR DESCRIPTION
## Problem

Closes #56 

Unlike mentioned in the issue this is not problematic for `formal/orm` as it compares the objects identity before calling the `equals` method.

But this problem could still exist elsewhere.

## Solution

Add a check at the start of the method to make an early return if the other `Set` is itself.

## Note

The same problem applied to `Sequence::equals()` and has been fixed the same way.