### PR TITLE
Add `ArrayMerge` monoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `Innmind\Immutable\Predicate\OrPredicate::and()`
 - `Innmind\Immutable\Predicate\AndPredicate::or()`
 - `Innmind\Immutable\Predicate\AndPredicate::and()`
+- `Innmind\Immutable\Monoid\ArrayMerge`
 
 ## 5.15.0 - 2025-05-17
 

--- a/docs/MONOIDS.md
+++ b/docs/MONOIDS.md
@@ -16,6 +16,7 @@ This library comes with a few monoids:
 - `Innmind\Immutable\Monoid\Append` to append 2 instances of `Innmind\Immutable\Sequence` together
 - `Innmind\Immutable\Monoid\MergeSet` to append 2 instances of `Innmind\Immutable\Set` together
 - `Innmind\Immutable\Monoid\MergeMap` to append 2 instances of `Innmind\Immutable\Map` together
+- `Innmind\Immutable\Monoid\ArrayMerge` to append 2 arrays together (keys are preserved)
 
 ## Create your own
 

--- a/proofs/monoid/arrayMerge.php
+++ b/proofs/monoid/arrayMerge.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\Immutable\{
+    Monoid\ArrayMerge,
+    Sequence,
+};
+use Innmind\BlackBox\Set;
+use Properties\Innmind\Immutable\Monoid;
+
+return static function() {
+    $equals = static fn($a, $b) => $a === $b;
+    $set = Set\Sequence::of(
+        Set\Randomize::of( // forced to randomize as the composite will try to reuse the same key
+            Set\Composite::immutable(
+                static fn($key, $value): array => [$key, $value],
+                Set\Integers::between(0, 200),
+                Set\Integers::between(0, 200),
+            ),
+        ),
+    )
+        ->between(1, 10)
+        ->filter(static function(array $pairs): bool {
+            $keys = \array_column($pairs, 0);
+
+            // checks unicity of values
+            return Sequence::of(...$keys)->size() === Sequence::of(...$keys)->distinct()->size();
+        })
+        ->map(static fn($pairs) => \array_combine(
+            \array_column($pairs, 0),
+            \array_column($pairs, 1),
+        ));
+
+    yield properties(
+        'ArrayMerge properties',
+        Monoid::properties($set, $equals),
+        Set\Elements::of(new ArrayMerge),
+    );
+
+    foreach (Monoid::list($set, $equals) as $property) {
+        yield proof(
+            'ArrayMerge property',
+            given($property),
+            static fn($assert, $property) => $property->ensureHeldBy($assert, new ArrayMerge),
+        );
+    }
+};

--- a/src/Monoid/ArrayMerge.php
+++ b/src/Monoid/ArrayMerge.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Immutable\Monoid;
+
+use Innmind\Immutable\Monoid;
+
+/**
+ * @template T of array-key
+ * @template U
+ * @psalm-immutable
+ * @implements Monoid<array<T, U>>
+ */
+final class ArrayMerge implements Monoid
+{
+    #[\Override]
+    public function identity(): mixed
+    {
+        /** @var array<T, U> */
+        return [];
+    }
+
+    /**
+     * @param array<T, U> $a
+     * @param array<T, U> $b
+     *
+     * @return array<T, U>
+     */
+    #[\Override]
+    public function combine(mixed $a, mixed $b): mixed
+    {
+        return \array_replace($a, $b);
+    }
+}


### PR DESCRIPTION
This will allow to replace the following code:

```php
Sequence::of(['foo' => 'bar'], ['bar' => 'baz'])->reduce(
    [],
    static fn($carry, $array) => \array_merge($carry, $array),
);
```

with:

```php
Sequence::of(['foo' => 'bar'], ['bar' => 'baz'])->fold(new ArrayMerge);
```

## Note

Internally it uses `array_replace` and not `array_merge` to make sure it has the same behaviour no matter the key type.