### PR TITLE
Make Monoids enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `Innmind\Immutable\Set` no longer implements `Countable`
 - Requires PHP `8.4`
 - `Innmind\Immutable\Predicate` is now a final class
+- `Innmind\Immutable\Monoid\*` are now enums with a single case called `monoid`
 
 ### Removed
 

--- a/docs/structures/sequence.md
+++ b/docs/structures/sequence.md
@@ -598,7 +598,7 @@ use Innmind\Immutable\Monoid\Concat;
 
 $lines = Sequence::of("foo\n", "bar\n", 'baz')
     ->map(fn($line) => Str::of($line))
-    ->fold(new Concat);
+    ->fold(Concat::monoid);
 
 $lines->equals("foo\nbar\nbaz"); // true
 ```

--- a/proofs/monoid/arrayMerge.php
+++ b/proofs/monoid/arrayMerge.php
@@ -32,14 +32,14 @@ return static function() {
     yield properties(
         'ArrayMerge properties',
         Monoid::properties($set, $equals),
-        Set::of(new ArrayMerge),
+        Set::of(ArrayMerge::monoid),
     );
 
     foreach (Monoid::list($set, $equals) as $property) {
         yield proof(
             'ArrayMerge property',
             given($property),
-            static fn($assert, $property) => $property->ensureHeldBy($assert, new ArrayMerge),
+            static fn($assert, $property) => $property->ensureHeldBy($assert, ArrayMerge::monoid),
         );
     }
 };

--- a/proofs/monoid/concat.php
+++ b/proofs/monoid/concat.php
@@ -15,14 +15,14 @@ return static function() {
     yield properties(
         'Concat properties',
         Monoid::properties($set, $equals),
-        Set::of(new Concat),
+        Set::of(Concat::monoid),
     );
 
     foreach (Monoid::list($set, $equals) as $property) {
         yield proof(
             'Concat property',
             given($property),
-            static fn($assert, $property) => $property->ensureHeldBy($assert, new Concat),
+            static fn($assert, $property) => $property->ensureHeldBy($assert, Concat::monoid),
         );
     }
 };

--- a/proofs/sequence.php
+++ b/proofs/sequence.php
@@ -96,7 +96,7 @@ return static function() {
                 $string,
                 $chunks
                     ->flatMap(static fn($chars) => $chars)
-                    ->fold(new Concat)
+                    ->fold(Concat::monoid)
                     ->toString(),
             );
         },

--- a/src/Monoid/Append.php
+++ b/src/Monoid/Append.php
@@ -13,8 +13,10 @@ use Innmind\Immutable\{
  * @psalm-immutable
  * @implements Monoid<Sequence<T>>
  */
-final class Append implements Monoid
+enum Append implements Monoid
 {
+    case monoid;
+
     /**
      * @template C of object
      *
@@ -26,7 +28,7 @@ final class Append implements Monoid
     public static function of(?string $class = null): self
     {
         /** @var self<C> */
-        return new self;
+        return self::monoid;
     }
 
     #[\Override]

--- a/src/Monoid/ArrayMerge.php
+++ b/src/Monoid/ArrayMerge.php
@@ -11,8 +11,10 @@ use Innmind\Immutable\Monoid;
  * @psalm-immutable
  * @implements Monoid<array<T, U>>
  */
-final class ArrayMerge implements Monoid
+enum ArrayMerge implements Monoid
 {
+    case monoid;
+
     #[\Override]
     public function identity(): mixed
     {

--- a/src/Monoid/Concat.php
+++ b/src/Monoid/Concat.php
@@ -12,8 +12,10 @@ use Innmind\Immutable\{
  * @psalm-immutable
  * @implements Monoid<Str>
  */
-final class Concat implements Monoid
+enum Concat implements Monoid
 {
+    case monoid;
+
     #[\Override]
     public function identity(): Str
     {

--- a/src/Monoid/MergeMap.php
+++ b/src/Monoid/MergeMap.php
@@ -14,8 +14,10 @@ use Innmind\Immutable\{
  * @psalm-immutable
  * @implements Monoid<Map<T, U>>
  */
-final class MergeMap implements Monoid
+enum MergeMap implements Monoid
 {
+    case monoid;
+
     /**
      * @template A of object
      * @template B of object
@@ -29,7 +31,7 @@ final class MergeMap implements Monoid
     public static function of(?string $key = null, ?string $value = null): self
     {
         /** @var self<A, B> */
-        return new self;
+        return self::monoid;
     }
 
     #[\Override]

--- a/src/Monoid/MergeSet.php
+++ b/src/Monoid/MergeSet.php
@@ -13,8 +13,10 @@ use Innmind\Immutable\{
  * @psalm-immutable
  * @implements Monoid<Set<T>>
  */
-final class MergeSet implements Monoid
+enum MergeSet implements Monoid
 {
+    case monoid;
+
     /**
      * @template C of object
      *
@@ -26,7 +28,7 @@ final class MergeSet implements Monoid
     public static function of(?string $class = null): self
     {
         /** @var self<C> */
-        return new self;
+        return self::monoid;
     }
 
     #[\Override]

--- a/tests/Monoid/ConcatTest.php
+++ b/tests/Monoid/ConcatTest.php
@@ -14,12 +14,12 @@ class ConcatTest extends TestCase
 {
     public function testInterface()
     {
-        $this->assertInstanceOf(Monoid::class, new Concat);
+        $this->assertInstanceOf(Monoid::class, Concat::monoid);
     }
 
     public function testCombine()
     {
-        $str = (new Concat)->combine(Str::of('foo'), Str::of('bar'));
+        $str = Concat::monoid->combine(Str::of('foo'), Str::of('bar'));
 
         $this->assertInstanceOf(Str::class, $str);
         $this->assertSame(

--- a/tests/SequenceTest.php
+++ b/tests/SequenceTest.php
@@ -852,12 +852,12 @@ class SequenceTest extends TestCase
 
     public function testFold()
     {
-        $str = Sequence::of(Str::of('foo'), Str::of('bar'), Str::of('baz'))->fold(new Concat);
+        $str = Sequence::of(Str::of('foo'), Str::of('bar'), Str::of('baz'))->fold(Concat::monoid);
 
         $this->assertInstanceOf(Str::class, $str);
         $this->assertSame('foobarbaz', $str->toString());
 
-        $str = Sequence::of(Str::of('baz'), Str::of('foo'), Str::of('bar'))->fold(new Concat);
+        $str = Sequence::of(Str::of('baz'), Str::of('foo'), Str::of('bar'))->fold(Concat::monoid);
 
         $this->assertInstanceOf(Str::class, $str);
         $this->assertSame('bazfoobar', $str->toString());


### PR DESCRIPTION
To avoid creating multiple instances that always do the same thing.